### PR TITLE
Hotfix: handle empty schedule for v1 injector

### DIFF
--- a/components/RewardsInjectorConfigurator.tsx
+++ b/components/RewardsInjectorConfigurator.tsx
@@ -93,11 +93,15 @@ function RewardsInjectorConfigurator({
 
   useEffect(() => {
     if (selectedAddress && injectorData) {
-      setTokenSymbol(injectorData.tokenInfo.symbol);
-      setTokenDecimals(injectorData.tokenInfo.symbol === "USDC" ? 6 : 18);
-      setGauges(injectorData.gauges);
-      setContractBalance(injectorData.contractBalance);
-      setCurrentConfig(injectorData.gauges);
+      // Add null checks and provide default values
+      setTokenSymbol(injectorData.tokenInfo?.symbol || selectedAddress.token || '');
+      setTokenDecimals(
+          injectorData.tokenInfo?.symbol === "USDC" ? 6 :
+              selectedAddress.token === "USDC" ? 6 : 18
+      );
+      setGauges(injectorData.gauges || []);
+      setContractBalance(injectorData.contractBalance || 0);
+      setCurrentConfig(injectorData.gauges || []);
     }
   }, [selectedAddress, injectorData]);
 

--- a/components/tables/RewardsInjectorTable.tsx
+++ b/components/tables/RewardsInjectorTable.tsx
@@ -88,13 +88,12 @@ export const RewardsInjectorTable: React.FC<RewardsInjectorTableProps> = ({
     const date = new Date(Number(timestamp) * 1000);
     if (date.getTime() === 0) return "-";
     return date.toLocaleString([], {
-      month: 'numeric',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: 'numeric',
+      month: "numeric",
+      day: "numeric",
+      hour: "numeric",
+      minute: "numeric",
     });
   };
-
 
   const SortableHeader: React.FC<{
     column: keyof RewardsInjectorData;
@@ -171,7 +170,7 @@ export const RewardsInjectorTable: React.FC<RewardsInjectorTableProps> = ({
       <Table variant="simple" size="sm">
         <Thead>
           <Tr>
-          <Th width="25%">
+            <Th width="25%">
               <SortableHeader column="gaugeAddress" label="Address" />
             </Th>
             {!isV2 && (
@@ -198,8 +197,11 @@ export const RewardsInjectorTable: React.FC<RewardsInjectorTableProps> = ({
               />
             </Th>
             {isV2 && (
-          <Th width="24%">
-                <SortableHeader column="doNotStartBeforeTimestamp" label="Starts At" />
+              <Th width="24%">
+                <SortableHeader
+                  column="doNotStartBeforeTimestamp"
+                  label="Starts At"
+                />
               </Th>
             )}
           </Tr>
@@ -210,9 +212,7 @@ export const RewardsInjectorTable: React.FC<RewardsInjectorTableProps> = ({
               <Td>
                 <AddressLink address={row.gaugeAddress} />
               </Td>
-              {!isV2 && (
-                <Td>{row.poolName}</Td>
-              )}
+              {!isV2 && <Td>{row.poolName}</Td>}
               <Td
                 isNumeric
               >{`${Number(row.amountPerPeriod).toFixed(2)} ${tokenSymbol}`}</Td>

--- a/lib/data/injector/helpers.ts
+++ b/lib/data/injector/helpers.ts
@@ -62,9 +62,7 @@ export async function fetchGaugeInfoV2(
         lastInjectionTimestamp,
         doNotStartBeforeTimestamp,
       },
-    ] = await Promise.all([
-      contract.getGaugeInfo(gaugeAddress),
-    ]);
+    ] = await Promise.all([contract.getGaugeInfo(gaugeAddress)]);
 
     return {
       gaugeAddress: gaugeAddress,


### PR DESCRIPTION
- if a v1 injector was freshly deployed, there is no tokenInfo
- see payload-builder/injector-configurator/0x9BE5CE14d1FD02517682aeC14c7162328E9e386e?version=v1