### PR TITLE
fix: injector loading states

### DIFF
--- a/app/api/injector/v2/factory/route.ts
+++ b/app/api/injector/v2/factory/route.ts
@@ -3,6 +3,9 @@ import { ethers } from "ethers";
 import { networks } from "@/constants/constants";
 import { fetchAddressBook, getCategoryData, getNetworks } from "@/lib/data/maxis/addressBook";
 
+// 5 min caching for factory
+const CACHE_DURATION = 300;
+
 const FACTORY_ABI = [
   {
     inputs: [],
@@ -42,8 +45,12 @@ export async function GET(request: NextRequest) {
         }
       }
     }
+    // Create the response with cache headers
+    const response = NextResponse.json(allInjectors);
+    // Set cache control headers
+    response.headers.set('Cache-Control', `s-maxage=${CACHE_DURATION}, stale-while-revalidate`);
+    return response;
 
-    return NextResponse.json(allInjectors);
   } catch (error) {
     console.error("Error:", error);
     return NextResponse.json({ error: "An error occurred while fetching data" }, { status: 500 });

--- a/app/rewards-injector/[...address]/page.tsx
+++ b/app/rewards-injector/[...address]/page.tsx
@@ -9,7 +9,8 @@ export default async function RewardsInjectorDetailPage({
   params: { address?: string[] };
 }) {
   const addressBook = await fetchAddressBook();
-  const injectorAddress = params.address?.[0] || null;
+  const networkFromPath = params.address?.[0] || null;
+  const injectorAddress = params.address?.[1] || null;
 
   return (
     <Suspense fallback={<Skeleton w="full" h="500px" />}>

--- a/components/RewardsInjectorConfigurationViewerV2.tsx
+++ b/components/RewardsInjectorConfigurationViewerV2.tsx
@@ -83,7 +83,7 @@ export const RewardsInjectorConfigurationViewerV2: React.FC<
                     borderColor={borderColor}
                   >
                     <VStack align="start" spacing={1}>
-                      <Text fontFamily="mono">{formatAddress(gauge.gaugeAddress)}</Text>
+                      <Text fontFamily="mono">{gauge.gaugeAddress}</Text>
                       <Text fontSize="sm" color={mutedTextColor}>
                         {gauge.poolName}
                       </Text>

--- a/components/RewardsInjectorConfigurator.tsx
+++ b/components/RewardsInjectorConfigurator.tsx
@@ -362,7 +362,7 @@ function RewardsInjectorConfigurator({
       )}
       <Divider />
 
-      {!selectedSafe && !isLoading && (
+      {!selectedAddress || (!selectedSafe && !isLoading) && (
         <Alert status="warning" mb={4}>
           <AlertIcon />
           <AlertDescription>

--- a/components/RewardsInjectorConfiguratorV2.tsx
+++ b/components/RewardsInjectorConfiguratorV2.tsx
@@ -50,6 +50,7 @@ import { JsonViewerEditor } from "@/components/JsonViewerEditor";
 import { getChainId } from "@/lib/utils/getChainId";
 import { RewardsInjectorConfigurationViewerV2 } from "./RewardsInjectorConfigurationViewerV2";
 import EditableInjectorConfigV2 from "./EditableInjectorConfigV2";
+import { uuidv4 } from "@walletconnect/utils";
 
 type RewardsInjectorConfiguratorV2Props = {
   addresses: AddressOption[];
@@ -71,15 +72,15 @@ interface RecipientConfigData {
 }
 
 function RewardsInjectorConfiguratorV2({
-  addresses,
-  selectedAddress,
-  onAddressSelect,
-  selectedSafe,
-  injectorData,
-  isLoading,
-  isV2,
-  onVersionToggle,
-}: RewardsInjectorConfiguratorV2Props) {
+                                         addresses,
+                                         selectedAddress,
+                                         onAddressSelect,
+                                         selectedSafe,
+                                         injectorData,
+                                         isLoading,
+                                         isV2,
+                                         onVersionToggle,
+                                       }: RewardsInjectorConfiguratorV2Props) {
   const [gauges, setGauges] = useState<RewardsInjectorData[]>([]);
   const [contractBalance, setContractBalance] = useState(0);
   const [tokenSymbol, setTokenSymbol] = useState("");
@@ -180,7 +181,6 @@ function RewardsInjectorConfiguratorV2({
           const gaugeDistributed = gaugeAmountPerPeriod * gaugePeriodNumber;
           const gaugeRemaining = gaugeTotal - gaugeDistributed;
 
-          console.log(gaugeTotal, gaugeDistributed, gaugeRemaining);
           newTotal -= gaugeTotal / 10 ** tokenDecimals;
           newDistributed -= gaugeDistributed / 10 ** tokenDecimals;
           newRemaining -= gaugeRemaining / 10 ** tokenDecimals;
@@ -240,14 +240,14 @@ function RewardsInjectorConfiguratorV2({
         scheduleInputs:
           operation === "add"
             ? addConfig.recipients.map(recipient => ({
-                gaugeAddress: recipient,
-                rawAmountPerPeriod: addConfig.rawAmountPerPeriod,
-                maxPeriods: addConfig.maxPeriods,
-                doNotStartBeforeTimestamp: addConfig.doNotStartBeforeTimestamp,
-              }))
+              gaugeAddress: recipient,
+              rawAmountPerPeriod: addConfig.rawAmountPerPeriod,
+              maxPeriods: addConfig.maxPeriods,
+              doNotStartBeforeTimestamp: addConfig.doNotStartBeforeTimestamp,
+            }))
             : removeConfig.recipients.map(recipient => ({
-                gaugeAddress: recipient,
-              })),
+              gaugeAddress: recipient,
+            })),
       });
 
       setGeneratedPayload(payload);
@@ -326,7 +326,7 @@ function RewardsInjectorConfiguratorV2({
           <MenuList w="135%" maxHeight="60vh" overflowY="auto">
             {addresses.map(address => (
               <MenuItem
-                key={address.network + address.token}
+                key={`${address.network}-${address.address}-${uuidv4()}`}
                 onClick={() => onAddressSelect(address)}
                 w="100%"
               >
@@ -352,7 +352,7 @@ function RewardsInjectorConfiguratorV2({
 
         {selectedAddress && (
           <IconButton
-            aria-label={""}
+            aria-label={"View on explorer"}
             as="a"
             href={`${networks[selectedAddress.network.toLowerCase()].explorer}address/${selectedAddress.address}`}
             target="_blank"


### PR DESCRIPTION
- handle loading for v2 injectors
- correctly fetch for single routes
- handle unique IDs / issues with v2 dropdown as addresses from factories can overlap + tokens for non-unique keys
- caching rule for factory fetching. Injector state will be fetched as is so it is up-to-date when user iteracts