### PR TITLE
Feature: Map Root gauges that are not yet in the gauge adder

### DIFF
--- a/app/api/gaugerecipients/route.ts
+++ b/app/api/gaugerecipients/route.ts
@@ -1,25 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-
-// API endpoint for the GraphQL subgraph
-const SUBGRAPH_URL = 'https://gateway-arbitrum.network.thegraph.com/api/' + process.env.GRAPH_API_KEY + '/subgraphs/id/4sESujoqmztX6pbichs4wZ1XXyYrkooMuHA8sKkYxpTn';
-
-// GraphQL query
-const GAUGE_RECIPIENTS_QUERY = `
-  query FetchGaugeRecipients($recipient: Bytes!) {
-    rootGauges(
-      where: {
-        recipient: $recipient
-      }
-    ) {
-      id
-      gauge {
-        id
-      }
-      isKilled
-      relativeWeightCap
-    }
-  }
-`;
+import { fetchGaugeRecipientsFromSubgraph } from "@/lib/data/subgraphs/fetchGaugeRecipients";
 
 export async function GET(request: NextRequest) {
   // Get the recipient from query parameters
@@ -34,33 +14,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    // Execute the GraphQL query
-    const response = await fetch(SUBGRAPH_URL, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        query: GAUGE_RECIPIENTS_QUERY,
-        variables: {
-          recipient,
-        },
-      }),
-    });
-
-    if (!response.ok) {
-      throw new Error(`GraphQL request failed with status: ${response.status}`);
-    }
-
-    const data = await response.json();
-
-    // Process the response to return just the list of gauges
-    const gauges = data.data.rootGauges.map((gauge: any) => ({
-      id: gauge.id,
-      gaugeId: gauge.gauge?.id || null,
-      isKilled: gauge.isKilled,
-    }));
-
+    const gauges = await fetchGaugeRecipientsFromSubgraph(recipient);
     return NextResponse.json({ gauges });
   } catch (error) {
     console.error('Error fetching gauge recipients:', error);
@@ -73,7 +27,6 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    // Get the recipient from request body
     const { recipient } = await request.json();
 
     if (!recipient) {
@@ -83,33 +36,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Execute the GraphQL query
-    const response = await fetch(SUBGRAPH_URL, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        query: GAUGE_RECIPIENTS_QUERY,
-        variables: {
-          recipient,
-        },
-      }),
-    });
-
-    if (!response.ok) {
-      throw new Error(`GraphQL request failed with status: ${response.status}`);
-    }
-
-    const data = await response.json();
-
-    // Process the response to return just the list of gauges
-    const gauges = data.data.rootGauges.map((gauge: any) => ({
-      id: gauge.id,
-      gaugeId: gauge.gauge?.id || null,
-      isKilled: gauge.isKilled,
-    }));
-
+    const gauges = await fetchGaugeRecipientsFromSubgraph(recipient);
     return NextResponse.json({ gauges });
   } catch (error) {
     console.error('Error fetching gauge recipients:', error);

--- a/app/api/gaugerecipients/route.ts
+++ b/app/api/gaugerecipients/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+// API endpoint for the GraphQL subgraph
+const SUBGRAPH_URL = 'https://gateway-arbitrum.network.thegraph.com/api/' + process.env.GRAPH_API_KEY + '/subgraphs/id/4sESujoqmztX6pbichs4wZ1XXyYrkooMuHA8sKkYxpTn';
+
+// GraphQL query
+const GAUGE_RECIPIENTS_QUERY = `
+  query FetchGaugeRecipients($recipient: Bytes!) {
+    rootGauges(
+      where: {
+        recipient: $recipient
+      }
+    ) {
+      id
+      gauge {
+        id
+      }
+      isKilled
+      relativeWeightCap
+    }
+  }
+`;
+
+export async function GET(request: NextRequest) {
+  // Get the recipient from query parameters
+  const searchParams = request.nextUrl.searchParams;
+  const recipient = searchParams.get('recipient');
+
+  if (!recipient) {
+    return NextResponse.json(
+      { error: 'Recipient parameter is required' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    // Execute the GraphQL query
+    const response = await fetch(SUBGRAPH_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        query: GAUGE_RECIPIENTS_QUERY,
+        variables: {
+          recipient,
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`GraphQL request failed with status: ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    // Process the response to return just the list of gauges
+    const gauges = data.data.rootGauges.map((gauge: any) => ({
+      id: gauge.id,
+      gaugeId: gauge.gauge?.id || null,
+      isKilled: gauge.isKilled,
+    }));
+
+    return NextResponse.json({ gauges });
+  } catch (error) {
+    console.error('Error fetching gauge recipients:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch gauge recipients' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    // Get the recipient from request body
+    const { recipient } = await request.json();
+
+    if (!recipient) {
+      return NextResponse.json(
+        { error: 'Recipient parameter is required' },
+        { status: 400 }
+      );
+    }
+
+    // Execute the GraphQL query
+    const response = await fetch(SUBGRAPH_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        query: GAUGE_RECIPIENTS_QUERY,
+        variables: {
+          recipient,
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`GraphQL request failed with status: ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    // Process the response to return just the list of gauges
+    const gauges = data.data.rootGauges.map((gauge: any) => ({
+      id: gauge.id,
+      gaugeId: gauge.gauge?.id || null,
+      isKilled: gauge.isKilled,
+    }));
+
+    return NextResponse.json({ gauges });
+  } catch (error) {
+    console.error('Error fetching gauge recipients:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch gauge recipients' },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/data/subgraphs/fetchGaugeRecipients.ts
+++ b/lib/data/subgraphs/fetchGaugeRecipients.ts
@@ -1,0 +1,51 @@
+// API endpoint for the GraphQL subgraph
+const SUBGRAPH_URL = 'https://gateway-arbitrum.network.thegraph.com/api/' + process.env.GRAPH_API_KEY + '/subgraphs/id/4sESujoqmztX6pbichs4wZ1XXyYrkooMuHA8sKkYxpTn';
+
+// GraphQL query
+const GAUGE_RECIPIENTS_QUERY = `
+  query FetchGaugeRecipients($recipient: Bytes!) {
+    rootGauges(
+      where: {
+        recipient: $recipient
+      }
+    ) {
+      id
+      gauge {
+        id
+      }
+      isKilled
+      relativeWeightCap
+    }
+  }
+`;
+
+// Core function to fetch gauge data
+export async function fetchGaugeRecipientsFromSubgraph(recipient: string) {
+  // Execute the GraphQL query
+  const response = await fetch(SUBGRAPH_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      query: GAUGE_RECIPIENTS_QUERY,
+      variables: {
+        recipient,
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`GraphQL request failed with status: ${response.status}`);
+  }
+
+  const data = await response.json();
+
+  // Process the response to return just the list of gauges
+  return data.data.rootGauges.map((gauge: any) => ({
+    id: gauge.id,
+    gaugeId: gauge.gauge?.id || null,
+    isKilled: gauge.isKilled,
+    relativeWeightCap: gauge.relativeWeightCap,
+  }));
+}

--- a/lib/services/apollo/generated/graphql.ts
+++ b/lib/services/apollo/generated/graphql.ts
@@ -26,10 +26,16 @@ export type Scalars = {
 /** The review data for the ERC4626 token */
 export type Erc4626ReviewData = {
   __typename: 'Erc4626ReviewData';
+  /** If it is an ERC4626 token, this defines whether we can use wrap/unwrap through the buffer in swap paths for this token. */
+  canUseBufferForSwaps?: Maybe<Scalars['Boolean']['output']>;
   /** The filename of the review of the ERC4626 */
   reviewFile: Scalars['String']['output'];
   /** A summary of the ERC4626 review, usually just says safe or unsafe */
   summary: Scalars['String']['output'];
+  /** If it is an ERC4626 token, this defines whether we allow underlying tokens to be used for add/remove operations. */
+  useUnderlyingForAddRemove?: Maybe<Scalars['Boolean']['output']>;
+  /** If it is an ERC4626 token, this defines whether we allow the wrapped tokens to be used for add/remove operations. */
+  useWrappedForAddRemove?: Maybe<Scalars['Boolean']['output']>;
   /** Warnings associated with the ERC4626 */
   warnings: Array<Scalars['String']['output']>;
 };
@@ -92,23 +98,6 @@ export enum GqlChain {
   Sepolia = 'SEPOLIA',
   Sonic = 'SONIC',
   Zkevm = 'ZKEVM'
-}
-
-export type GqlContentNewsItem = {
-  __typename: 'GqlContentNewsItem';
-  discussionUrl?: Maybe<Scalars['String']['output']>;
-  id: Scalars['ID']['output'];
-  image?: Maybe<Scalars['String']['output']>;
-  source: GqlContentNewsItemSource;
-  text: Scalars['String']['output'];
-  timestamp: Scalars['String']['output'];
-  url: Scalars['String']['output'];
-};
-
-export enum GqlContentNewsItemSource {
-  Discord = 'discord',
-  Medium = 'medium',
-  Twitter = 'twitter'
 }
 
 export type GqlFeaturePoolGroupItemExternalLink = {
@@ -343,6 +332,8 @@ export type GqlPoolAggregator = {
   poolTokens: Array<GqlPoolTokenDetail>;
   /** The protocol version on which the pool is deployed, 1, 2 or 3 */
   protocolVersion: Scalars['Int']['output'];
+  /** QuantAmmWeighted specific fields */
+  quantAmmWeightedParams?: Maybe<QuantAmmWeightedParams>;
   /** Data specific to gyro pools */
   root3Alpha?: Maybe<Scalars['String']['output']>;
   /** Data specific to gyro pools */
@@ -1290,6 +1281,61 @@ export enum GqlPoolOrderDirection {
   Desc = 'desc'
 }
 
+export type GqlPoolQuantAmmWeighted = GqlPoolBase & {
+  __typename: 'GqlPoolQuantAmmWeighted';
+  address: Scalars['Bytes']['output'];
+  /** @deprecated Use poolTokens instead */
+  allTokens: Array<GqlPoolTokenExpanded>;
+  categories?: Maybe<Array<Maybe<GqlPoolFilterCategory>>>;
+  chain: GqlChain;
+  createTime: Scalars['Int']['output'];
+  decimals: Scalars['Int']['output'];
+  /** @deprecated Use poolTokens instead */
+  displayTokens: Array<GqlPoolTokenDisplay>;
+  dynamicData: GqlPoolDynamicData;
+  factory?: Maybe<Scalars['Bytes']['output']>;
+  hasAnyAllowedBuffer: Scalars['Boolean']['output'];
+  hasErc4626: Scalars['Boolean']['output'];
+  hasNestedErc4626: Scalars['Boolean']['output'];
+  hook?: Maybe<GqlHook>;
+  id: Scalars['ID']['output'];
+  /** @deprecated Removed without replacement */
+  investConfig: GqlPoolInvestConfig;
+  liquidityManagement?: Maybe<LiquidityManagement>;
+  name: Scalars['String']['output'];
+  /** @deprecated Removed without replacement */
+  nestingType: GqlPoolNestingType;
+  /**
+   * The wallet address of the owner of the pool. Pool owners can set certain properties like swapFees or AMP.
+   * @deprecated Use swapFeeManager instead
+   */
+  owner?: Maybe<Scalars['Bytes']['output']>;
+  /** Account empowered to pause/unpause the pool (or 0 to delegate to governance) */
+  pauseManager?: Maybe<Scalars['Bytes']['output']>;
+  /** Account empowered to set the pool creator fee percentage */
+  poolCreator?: Maybe<Scalars['Bytes']['output']>;
+  poolTokens: Array<GqlPoolTokenDetail>;
+  protocolVersion: Scalars['Int']['output'];
+  quantAmmWeightedParams?: Maybe<QuantAmmWeightedParams>;
+  staking?: Maybe<GqlPoolStaking>;
+  /** Account empowered to set static swap fees for a pool (when 0 on V2 swap fees are immutable, on V3 delegate to governance) */
+  swapFeeManager?: Maybe<Scalars['Bytes']['output']>;
+  symbol: Scalars['String']['output'];
+  tags?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  /**
+   * All tokens of the pool. If it is a nested pool, the nested pool is expanded with its own tokens again.
+   * @deprecated Use poolTokens instead
+   */
+  tokens: Array<GqlPoolTokenUnion>;
+  type: GqlPoolType;
+  userBalance?: Maybe<GqlPoolUserBalance>;
+  /** @deprecated use protocolVersion instead */
+  vaultVersion: Scalars['Int']['output'];
+  version: Scalars['Int']['output'];
+  /** @deprecated Removed without replacement */
+  withdrawConfig: GqlPoolWithdrawConfig;
+};
+
 export type GqlPoolSnapshot = {
   __typename: 'GqlPoolSnapshot';
   amounts: Array<Scalars['String']['output']>;
@@ -1733,12 +1779,13 @@ export enum GqlPoolType {
   LiquidityBootstrapping = 'LIQUIDITY_BOOTSTRAPPING',
   MetaStable = 'META_STABLE',
   PhantomStable = 'PHANTOM_STABLE',
+  QuantAmmWeighted = 'QUANT_AMM_WEIGHTED',
   Stable = 'STABLE',
   Unknown = 'UNKNOWN',
   Weighted = 'WEIGHTED'
 }
 
-export type GqlPoolUnion = GqlPoolComposableStable | GqlPoolElement | GqlPoolFx | GqlPoolGyro | GqlPoolLiquidityBootstrapping | GqlPoolMetaStable | GqlPoolStable | GqlPoolWeighted;
+export type GqlPoolUnion = GqlPoolComposableStable | GqlPoolElement | GqlPoolFx | GqlPoolGyro | GqlPoolLiquidityBootstrapping | GqlPoolMetaStable | GqlPoolQuantAmmWeighted | GqlPoolStable | GqlPoolWeighted;
 
 /** If a user address was provided in the query, the user balance is populated here */
 export type GqlPoolUserBalance = {
@@ -2274,6 +2321,7 @@ export type GqlToken = {
   tradable: Scalars['Boolean']['output'];
   /** The Twitter username of the token */
   twitterUsername?: Maybe<Scalars['String']['output']>;
+  types?: Maybe<Array<GqlTokenType>>;
   /** The ERC4626 underlying token address, if applicable. */
   underlyingTokenAddress?: Maybe<Scalars['String']['output']>;
   /** The website URL of the token */
@@ -2354,6 +2402,8 @@ export type GqlTokenDynamicData = {
 export type GqlTokenFilter = {
   /** Only return tokens with these addresses */
   tokensIn?: InputMaybe<Array<Scalars['String']['input']>>;
+  /** Filter by token type */
+  typeIn?: InputMaybe<Array<GqlTokenType>>;
 };
 
 /** Result of the poolReloadPools mutation */
@@ -2385,6 +2435,7 @@ export type GqlTokenPriceChartDataItem = {
 
 export enum GqlTokenType {
   Bpt = 'BPT',
+  Erc4626 = 'ERC4626',
   PhantomBpt = 'PHANTOM_BPT',
   WhiteListed = 'WHITE_LISTED'
 }
@@ -2669,6 +2720,30 @@ export type PoolForBatchSwap = {
   type: GqlPoolType;
 };
 
+export type QuantAmmWeightedDetail = {
+  __typename: 'QuantAMMWeightedDetail';
+  category: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  type: Scalars['String']['output'];
+  value: Scalars['String']['output'];
+};
+
+export type QuantAmmWeightedParams = {
+  __typename: 'QuantAmmWeightedParams';
+  absoluteWeightGuardRail: Scalars['String']['output'];
+  details: Array<QuantAmmWeightedDetail>;
+  epsilonMax: Scalars['String']['output'];
+  lambda: Array<Scalars['String']['output']>;
+  lastInterpolationTimePossible: Scalars['String']['output'];
+  lastUpdateIntervalTime: Scalars['String']['output'];
+  maxTradeSizeRatio: Scalars['String']['output'];
+  oracleStalenessThreshold: Scalars['String']['output'];
+  poolRegistry: Scalars['String']['output'];
+  updateInterval: Scalars['String']['output'];
+  weightBlockMultipliers: Array<Scalars['String']['output']>;
+  weightsAtLastUpdateInterval: Array<Scalars['String']['output']>;
+};
+
 export type Query = {
   __typename: 'Query';
   /** Returns all pools for a given filter, specific for aggregators */
@@ -2683,7 +2758,6 @@ export type Query = {
   blocksGetBlocksPerSecond: Scalars['Float']['output'];
   /** @deprecated No longer supported */
   blocksGetBlocksPerYear: Scalars['Float']['output'];
-  contentGetNewsItems: Array<GqlContentNewsItem>;
   latestSyncedBlocks: GqlLatestSyncedBlocks;
   /** Getting swap, add and remove events with paging */
   poolEvents: Array<GqlPoolEvent>;
@@ -2699,11 +2773,6 @@ export type Query = {
   poolGetBatchSwaps: Array<GqlPoolBatchSwap>;
   /** Getting swap, add and remove events with range */
   poolGetEvents: Array<GqlPoolEvent>;
-  /**
-   * Will de deprecated in favor of poolGetFeaturedPools
-   * @deprecated Use poolGetFeaturedPools instead
-   */
-  poolGetFeaturedPoolGroups: Array<GqlPoolFeaturedPoolGroup>;
   /** Returns the list of featured pools for chains */
   poolGetFeaturedPools: Array<GqlPoolFeaturedPool>;
   /**
@@ -2807,11 +2876,6 @@ export type QueryBeetsPoolGetReliquaryFarmSnapshotsArgs = {
 };
 
 
-export type QueryContentGetNewsItemsArgs = {
-  chain?: InputMaybe<GqlChain>;
-};
-
-
 export type QueryPoolEventsArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   skip?: InputMaybe<Scalars['Int']['input']>;
@@ -2841,11 +2905,6 @@ export type QueryPoolGetEventsArgs = {
   range: GqlPoolEventsDataRange;
   typeIn: Array<GqlPoolEventType>;
   userAddress?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-export type QueryPoolGetFeaturedPoolGroupsArgs = {
-  chains?: InputMaybe<Array<GqlChain>>;
 };
 
 

--- a/lib/services/apollo/generated/schema.graphql
+++ b/lib/services/apollo/generated/schema.graphql
@@ -10,11 +10,26 @@ scalar Date
 
 """The review data for the ERC4626 token"""
 type Erc4626ReviewData {
+  """
+  If it is an ERC4626 token, this defines whether we can use wrap/unwrap through the buffer in swap paths for this token.
+  """
+  canUseBufferForSwaps: Boolean
+
   """The filename of the review of the ERC4626"""
   reviewFile: String!
 
   """A summary of the ERC4626 review, usually just says safe or unsafe"""
   summary: String!
+
+  """
+  If it is an ERC4626 token, this defines whether we allow underlying tokens to be used for add/remove operations.
+  """
+  useUnderlyingForAddRemove: Boolean
+
+  """
+  If it is an ERC4626 token, this defines whether we allow the wrapped tokens to be used for add/remove operations.
+  """
+  useWrappedForAddRemove: Boolean
 
   """Warnings associated with the ERC4626"""
   warnings: [String!]!
@@ -76,22 +91,6 @@ enum GqlChain {
   SEPOLIA
   SONIC
   ZKEVM
-}
-
-type GqlContentNewsItem {
-  discussionUrl: String
-  id: ID!
-  image: String
-  source: GqlContentNewsItemSource!
-  text: String!
-  timestamp: String!
-  url: String!
-}
-
-enum GqlContentNewsItemSource {
-  discord
-  medium
-  twitter
 }
 
 type GqlFeaturePoolGroupItemExternalLink {
@@ -373,6 +372,9 @@ type GqlPoolAggregator {
 
   """The protocol version on which the pool is deployed, 1, 2 or 3"""
   protocolVersion: Int!
+
+  """QuantAmmWeighted specific fields"""
+  quantAmmWeightedParams: QuantAmmWeightedParams
 
   """Data specific to gyro pools"""
   root3Alpha: String
@@ -1435,6 +1437,61 @@ enum GqlPoolOrderDirection {
   desc
 }
 
+type GqlPoolQuantAmmWeighted implements GqlPoolBase {
+  address: Bytes!
+  allTokens: [GqlPoolTokenExpanded!]! @deprecated(reason: "Use poolTokens instead")
+  categories: [GqlPoolFilterCategory]
+  chain: GqlChain!
+  createTime: Int!
+  decimals: Int!
+  displayTokens: [GqlPoolTokenDisplay!]! @deprecated(reason: "Use poolTokens instead")
+  dynamicData: GqlPoolDynamicData!
+  factory: Bytes
+  hasAnyAllowedBuffer: Boolean!
+  hasErc4626: Boolean!
+  hasNestedErc4626: Boolean!
+  hook: GqlHook
+  id: ID!
+  investConfig: GqlPoolInvestConfig! @deprecated(reason: "Removed without replacement")
+  liquidityManagement: LiquidityManagement
+  name: String!
+  nestingType: GqlPoolNestingType! @deprecated(reason: "Removed without replacement")
+
+  """
+  The wallet address of the owner of the pool. Pool owners can set certain properties like swapFees or AMP.
+  """
+  owner: Bytes @deprecated(reason: "Use swapFeeManager instead")
+
+  """
+  Account empowered to pause/unpause the pool (or 0 to delegate to governance)
+  """
+  pauseManager: Bytes
+
+  """Account empowered to set the pool creator fee percentage"""
+  poolCreator: Bytes
+  poolTokens: [GqlPoolTokenDetail!]!
+  protocolVersion: Int!
+  quantAmmWeightedParams: QuantAmmWeightedParams
+  staking: GqlPoolStaking
+
+  """
+  Account empowered to set static swap fees for a pool (when 0 on V2 swap fees are immutable, on V3 delegate to governance)
+  """
+  swapFeeManager: Bytes
+  symbol: String!
+  tags: [String]
+
+  """
+  All tokens of the pool. If it is a nested pool, the nested pool is expanded with its own tokens again.
+  """
+  tokens: [GqlPoolTokenUnion!]! @deprecated(reason: "Use poolTokens instead")
+  type: GqlPoolType!
+  userBalance: GqlPoolUserBalance
+  vaultVersion: Int! @deprecated(reason: "use protocolVersion instead")
+  version: Int!
+  withdrawConfig: GqlPoolWithdrawConfig! @deprecated(reason: "Removed without replacement")
+}
+
 type GqlPoolSnapshot {
   amounts: [String!]!
   chain: GqlChain!
@@ -1928,12 +1985,13 @@ enum GqlPoolType {
   LIQUIDITY_BOOTSTRAPPING
   META_STABLE
   PHANTOM_STABLE
+  QUANT_AMM_WEIGHTED
   STABLE
   UNKNOWN
   WEIGHTED
 }
 
-union GqlPoolUnion = GqlPoolComposableStable | GqlPoolElement | GqlPoolFx | GqlPoolGyro | GqlPoolLiquidityBootstrapping | GqlPoolMetaStable | GqlPoolStable | GqlPoolWeighted
+union GqlPoolUnion = GqlPoolComposableStable | GqlPoolElement | GqlPoolFx | GqlPoolGyro | GqlPoolLiquidityBootstrapping | GqlPoolMetaStable | GqlPoolQuantAmmWeighted | GqlPoolStable | GqlPoolWeighted
 
 """
 If a user address was provided in the query, the user balance is populated here
@@ -2580,6 +2638,7 @@ type GqlToken {
 
   """The Twitter username of the token"""
   twitterUsername: String
+  types: [GqlTokenType!]
 
   """The ERC4626 underlying token address, if applicable."""
   underlyingTokenAddress: String
@@ -2673,6 +2732,9 @@ type GqlTokenDynamicData {
 input GqlTokenFilter {
   """Only return tokens with these addresses"""
   tokensIn: [String!]
+
+  """Filter by token type"""
+  typeIn: [GqlTokenType!]
 }
 
 """Result of the poolReloadPools mutation"""
@@ -2703,6 +2765,7 @@ type GqlTokenPriceChartDataItem {
 
 enum GqlTokenType {
   BPT
+  ERC4626
   PHANTOM_BPT
   WHITE_LISTED
 }
@@ -2933,6 +2996,28 @@ type PoolForBatchSwap {
   type: GqlPoolType!
 }
 
+type QuantAMMWeightedDetail {
+  category: String!
+  name: String!
+  type: String!
+  value: String!
+}
+
+type QuantAmmWeightedParams {
+  absoluteWeightGuardRail: String!
+  details: [QuantAMMWeightedDetail!]!
+  epsilonMax: String!
+  lambda: [String!]!
+  lastInterpolationTimePossible: String!
+  lastUpdateIntervalTime: String!
+  maxTradeSizeRatio: String!
+  oracleStalenessThreshold: String!
+  poolRegistry: String!
+  updateInterval: String!
+  weightBlockMultipliers: [String!]!
+  weightsAtLastUpdateInterval: [String!]!
+}
+
 type Query {
   """Returns all pools for a given filter, specific for aggregators"""
   aggregatorPools(first: Int, orderBy: GqlPoolOrderBy, orderDirection: GqlPoolOrderDirection, skip: Int, where: GqlAggregatorPoolFilter): [GqlPoolAggregator!]!
@@ -2942,7 +3027,6 @@ type Query {
   blocksGetBlocksPerDay: Float! @deprecated
   blocksGetBlocksPerSecond: Float! @deprecated
   blocksGetBlocksPerYear: Float! @deprecated
-  contentGetNewsItems(chain: GqlChain): [GqlContentNewsItem!]!
   latestSyncedBlocks: GqlLatestSyncedBlocks!
 
   """Getting swap, add and remove events with paging"""
@@ -2956,9 +3040,6 @@ type Query {
 
   """Getting swap, add and remove events with range"""
   poolGetEvents(chain: GqlChain!, poolId: String!, range: GqlPoolEventsDataRange!, typeIn: [GqlPoolEventType!]!, userAddress: String): [GqlPoolEvent!]!
-
-  """Will de deprecated in favor of poolGetFeaturedPools"""
-  poolGetFeaturedPoolGroups(chains: [GqlChain!]): [GqlPoolFeaturedPoolGroup!]! @deprecated(reason: "Use poolGetFeaturedPools instead")
 
   """Returns the list of featured pools for chains"""
   poolGetFeaturedPools(chains: [GqlChain!]!): [GqlPoolFeaturedPool!]!

--- a/lib/utils/fetchGaugeRecipients.ts
+++ b/lib/utils/fetchGaugeRecipients.ts
@@ -1,0 +1,20 @@
+/**
+ * Fetches gauge recipients for a given address
+ * @param recipient The recipient address to query
+ * @returns A promise resolving to the list of gauges
+ */
+export async function fetchGaugeRecipients(recipient: string) {
+  try {
+    const response = await fetch(`/api/gaugerecipients?recipient=${encodeURIComponent(recipient)}`);
+
+    if (!response.ok) {
+      throw new Error(`API request failed with status: ${response.status}`);
+    }
+
+    const data = await response.json();
+    return data.gauges;
+  } catch (error) {
+    console.error('Error fetching gauge recipients:', error);
+    throw error;
+  }
+}

--- a/types/interfaces.ts
+++ b/types/interfaces.ts
@@ -238,3 +238,10 @@ export interface Hook {
   type: string;
   params?: HookParams;
 }
+
+export interface GaugeRecipientData {
+  id: string;
+  gaugeId: string | null;
+  isKilled: boolean;
+  relativeWeightCap: number;
+}


### PR DESCRIPTION
- if there are root gauges identified in the gauges subgraph, then we will map and display them, even if they haven't been added to the gauge controller (and API-v3)
- additional logic for weight cap info etc
- simple data fetching without types (no codegen for that needed)