### PR TITLE
Injector fetching performance improvement

### DIFF
--- a/app/api/injector/v2/factory/route.ts
+++ b/app/api/injector/v2/factory/route.ts
@@ -6,6 +6,9 @@ import { fetchAddressBook, getCategoryData, getNetworks } from "@/lib/data/maxis
 // 5 min caching for factory
 const CACHE_DURATION = 300;
 
+// Configure route segment caching
+export const revalidate = 300;
+
 const FACTORY_ABI = [
   {
     inputs: [],

--- a/app/api/injector/v2/single/route.ts
+++ b/app/api/injector/v2/single/route.ts
@@ -11,6 +11,11 @@ import {
 import { Contract } from "ethers";
 import { gaugeABI } from "@/abi/gauge";
 
+const CACHE_DURATION = 300;
+
+// Configure route segment caching
+export const revalidate = 300;
+
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const address = searchParams.get("address");
@@ -92,7 +97,7 @@ export async function GET(request: NextRequest) {
       tokenInfo.decimals,
     );
 
-    return NextResponse.json({
+    const response = NextResponse.json({
       tokenInfo,
       gauges,
       contractBalance,
@@ -102,6 +107,8 @@ export async function GET(request: NextRequest) {
       maxGlobalAmountPerPeriod: maxGlobalAmountPerPeriod.toString(),
       maxTotalDue: maxTotalDue.toString(),
     });
+    response.headers.set("Cache-Control", `s-maxage=${CACHE_DURATION}, stale-while-revalidate`);
+    return response;
   } catch (error) {
     console.error("Error:", error);
     return NextResponse.json({ error: "An error occurred while fetching data" }, { status: 500 });

--- a/app/api/injector/v2/single/route.ts
+++ b/app/api/injector/v2/single/route.ts
@@ -73,7 +73,6 @@ export async function GET(request: NextRequest) {
           gaugeContract.lp_token().catch(() => null),
         ]);
 
-        // Fetch poolName in parallel if lpToken exists
         const poolName = lpToken
           ? await fetchPoolName(lpToken, provider).catch(() => gauge.gaugeAddress)
           : gauge.gaugeAddress;

--- a/components/RewardsInjector.tsx
+++ b/components/RewardsInjector.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   Alert,
   AlertDescription,
@@ -37,16 +37,6 @@ import {
   RewardsInjectorTable,
 } from "@/components/tables/RewardsInjectorTable";
 import { AddressOption } from "@/types/interfaces";
-import { formatTokenName } from "@/lib/utils/formatTokenName";
-
-type Recipient = {
-  gaugeAddress: string;
-  poolName?: string;
-  amountPerPeriod?: string;
-  maxPeriods: string;
-  periodNumber: string;
-  lastInjectionTimeStamp: string;
-};
 
 type RewardsInjectorProps = {
   addresses: AddressOption[];

--- a/components/RewardsInjectorContainer.tsx
+++ b/components/RewardsInjectorContainer.tsx
@@ -75,12 +75,12 @@ export default function RewardsInjectorContainer({
             const data = await response.json();
 
             if (Array.isArray(data)) {
-              const allPromises = [];
+              const injectorPromises = [];
               for (const item of data) {
                 const network = item.network;
                 // Create promises for each injector
                 for (const address of item.deployedInjectors) {
-                  allPromises.push(
+                  injectorPromises.push(
                     fetch(`/api/injector/v2/single?address=${address}&network=${network}`)
                       .then(response => response.json())
                       .then(tokenData => ({
@@ -105,7 +105,7 @@ export default function RewardsInjectorContainer({
               }
 
               // Wait for all promises to resolve
-              const results = await Promise.all(allPromises);
+              const results = await Promise.all(injectorPromises);
               allAddressesWithOptions.push(...results);
             }
           }

--- a/components/RewardsInjectorContainer.tsx
+++ b/components/RewardsInjectorContainer.tsx
@@ -74,7 +74,6 @@ export default function RewardsInjectorContainer({
             const response = await fetch(`/api/injector/v2/factory`);
             const data = await response.json();
 
-            console.time("fetchInjectorDataV2"); // Start timing
             if (Array.isArray(data)) {
               const allPromises = [];
               for (const item of data) {
@@ -109,7 +108,6 @@ export default function RewardsInjectorContainer({
               const results = await Promise.all(allPromises);
               allAddressesWithOptions.push(...results);
             }
-            console.timeEnd("fetchInjectorDataV2"); // End timing
           }
         } else {
           // V1 injectors loading logic

--- a/lib/services/apollo/generated/graphql.ts
+++ b/lib/services/apollo/generated/graphql.ts
@@ -180,6 +180,7 @@ export type GqlHookReviewData = {
 };
 
 export enum GqlHookType {
+  Akron = 'AKRON',
   DirectionalFee = 'DIRECTIONAL_FEE',
   ExitFee = 'EXIT_FEE',
   FeeTaking = 'FEE_TAKING',

--- a/lib/services/apollo/generated/schema.graphql
+++ b/lib/services/apollo/generated/schema.graphql
@@ -159,6 +159,7 @@ type GqlHookReviewData {
 }
 
 enum GqlHookType {
+  AKRON
   DIRECTIONAL_FEE
   EXIT_FEE
   FEE_TAKING


### PR DESCRIPTION
Improved injector fetching mechanism, now everything takes 2-3 seconds to load.

- parallelization of api route calls in `RewardsInjectorContainer`
- batched all the contract and api calls in api routes
- added next.js route segment caching to api routes

Considered multicall for contract calls in api routes, but benefit was not really noticeable, so rolled it back.