### PR TITLE
Injector status board improvements

### DIFF
--- a/app/rewards-injector/status/page.tsx
+++ b/app/rewards-injector/status/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import {
   SimpleGrid,
   Box,
@@ -235,6 +235,7 @@ const RewardsInjectorStatusPage = () => {
             <Skeleton h={8} w="40%" />
             <Skeleton h={8} w="10%" />
           </HStack>
+          <Skeleton h={20} w="full" />
           <Skeleton h={10} w="full" />
           <HStack justifyContent="space-between" alignItems="center" spacing={1}>
             <Skeleton h={6} w="30%" />
@@ -254,6 +255,19 @@ const RewardsInjectorStatusPage = () => {
     );
   }
 
+  // Calculate stats for display
+  const stats = {
+    total: injectorsData.length,
+    expired: injectorsData.filter((injector: any) => injector.hasExpiredGauges).length,
+    needsAttention: injectorsData.filter((injector: any) => injector.hasGaugesNearExpiration)
+      .length,
+    stale: injectorsData.filter((injector: any) => injector.isStale).length,
+  };
+
+  const statsHeaderTextColor = useColorModeValue("gray.600", "gray.400");
+  const statsBgColor = useColorModeValue("gray.50", "background.level2");
+  const statsBorderColor = useColorModeValue("gray.100", "whiteAlpha.100");
+
   return (
     <Container maxW="container.lg" justifyContent="center" alignItems="center">
       <VStack spacing={4} align="stretch">
@@ -270,6 +284,60 @@ const RewardsInjectorStatusPage = () => {
             />
           </Tooltip>
         </HStack>
+        {/* Compact Stats Overview */}
+        <SimpleGrid
+          columns={4}
+          spacing={4}
+          p={4}
+          bg={statsBgColor}
+          borderRadius="lg"
+          boxShadow="md"
+          borderWidth={1}
+          borderColor={statsBorderColor}
+          mb={1}
+        >
+          <VStack spacing={1}>
+            <Text fontSize="xs" color={statsHeaderTextColor} textAlign="center">
+              Total injectors
+            </Text>
+            <Text fontSize="xl" fontWeight="semibold">
+              {stats.total}
+            </Text>
+          </VStack>
+          <Tooltip label="Some gauges are about to expire" hasArrow>
+            <VStack spacing={1} cursor="pointer">
+              <Text fontSize="xs" color={statsHeaderTextColor} textAlign="center">
+                Needs attention
+              </Text>
+              <Text fontSize="xl" fontWeight="semibold">
+                {stats.needsAttention}
+              </Text>
+            </VStack>
+          </Tooltip>
+          <Tooltip
+            label="Injectors have some gauges that are expired and are no longer distributing rewards"
+            hasArrow
+          >
+            <VStack spacing={1} cursor="pointer">
+              <Text fontSize="xs" color={statsHeaderTextColor} textAlign="center">
+                With expired gauges
+              </Text>
+              <Text fontSize="xl" fontWeight="semibold">
+                {stats.expired}
+              </Text>
+            </VStack>
+          </Tooltip>
+          <Tooltip label="All gauges haven't fired for more than 2 weeks" hasArrow>
+            <VStack spacing={1} cursor="pointer">
+              <Text fontSize="xs" color={statsHeaderTextColor} textAlign="center">
+                Stale
+              </Text>
+              <Text fontSize="xl" fontWeight="semibold">
+                {stats.stale}
+              </Text>
+            </VStack>
+          </Tooltip>
+        </SimpleGrid>
         <Alert status="warning" mr={4}>
           <AlertIcon />
           <Box>

--- a/app/rewards-injector/status/page.tsx
+++ b/app/rewards-injector/status/page.tsx
@@ -17,6 +17,7 @@ import {
   Alert,
   AlertIcon,
   AlertDescription,
+  useColorModeValue,
 } from "@chakra-ui/react";
 import RewardsInjectorCard from "@/components/RewardsInjectorCard";
 import { networks } from "@/constants/constants";
@@ -189,7 +190,68 @@ const RewardsInjectorStatusPage = () => {
   }
 
   if (isLoading) {
-    return <Skeleton height="400px" />;
+    // Skeleton card visually matching RewardsInjectorCard
+    const RewardsInjectorCardSkeleton = () => (
+      <Box
+        borderRadius="lg"
+        boxShadow="md"
+        p={{ base: 2, md: 4 }}
+        minH="320px"
+        display="flex"
+        flexDirection="column"
+        justifyContent="space-between"
+      >
+        <HStack align="center" mb={4}>
+          <Skeleton boxSize={8} borderRadius="full" flexShrink={0} />
+          <VStack align="start" spacing={1} flex={1}>
+            <Skeleton h={4} w="60%" />
+            <Skeleton h={3} w="40%" />
+          </VStack>
+          <Skeleton h={6} w={"48px"} borderRadius="md" flexShrink={0} />
+        </HStack>
+        <VStack align="stretch" spacing={3} flex={1}>
+          <HStack justify="space-between">
+            <Skeleton h={4} w="40%" />
+            <Skeleton h={4} w="20%" />
+          </HStack>
+          <HStack justify="space-between">
+            <Skeleton h={4} w="40%" />
+            <Skeleton h={4} w="20%" />
+          </HStack>
+          <Skeleton h={2} w="full" borderRadius="full" />
+          <HStack justify="space-between">
+            <Skeleton h={4} w="40%" />
+            <Skeleton h={4} w="20%" />
+          </HStack>
+        </VStack>
+        <Skeleton h={9} w="full" mt={4} borderRadius="md" />
+      </Box>
+    );
+
+    return (
+      <Container maxW="container.lg" justifyContent="center" alignItems="center">
+        <VStack spacing={4} align="stretch">
+          <HStack justifyContent="space-between" alignItems="center">
+            <Skeleton h={8} w="40%" />
+            <Skeleton h={8} w="10%" />
+          </HStack>
+          <Skeleton h={10} w="full" />
+          <HStack justifyContent="space-between" alignItems="center" spacing={1}>
+            <Skeleton h={6} w="30%" />
+            <HStack spacing={2} w="60%">
+              <Skeleton h={8} w="30%" />
+              <Skeleton h={8} w="30%" />
+              <Skeleton h={8} w="20%" />
+            </HStack>
+          </HStack>
+          <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={4}>
+            {[...Array(6)].map((_, i) => (
+              <RewardsInjectorCardSkeleton key={i} />
+            ))}
+          </SimpleGrid>
+        </VStack>
+      </Container>
+    );
   }
 
   return (

--- a/components/RewardsInjectorCard.tsx
+++ b/components/RewardsInjectorCard.tsx
@@ -128,7 +128,7 @@ const RewardsInjectorCard: React.FC<RewardsInjectorCardProps> = ({ data, network
             {hasExpiredGauges && (
               <Tooltip label="Some gauges are expired and are no longer distributing rewards">
                 <Box
-                  bg="red.500"
+                  bg="red.700"
                   color="white"
                   px={2}
                   py={0.5}
@@ -137,7 +137,7 @@ const RewardsInjectorCard: React.FC<RewardsInjectorCardProps> = ({ data, network
                   display="flex"
                   alignItems="center"
                   gap={1}
-                  _hover={{ bg: "red.400" }}
+                  _hover={{ bg: "red.500" }}
                 >
                   <BiTimeFive size={14} />
                   <Text fontSize="xs" fontWeight="medium">
@@ -158,7 +158,7 @@ const RewardsInjectorCard: React.FC<RewardsInjectorCardProps> = ({ data, network
                   display="flex"
                   alignItems="center"
                   gap={1}
-                  _hover={{ bg: "yellow.400" }}
+                  _hover={{ bg: "yellow.500" }}
                 >
                   <WarningIcon boxSize={3} />
                   <Text fontSize="xs" fontWeight="medium">

--- a/components/RewardsInjectorCard.tsx
+++ b/components/RewardsInjectorCard.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import {
-  Card as ChakraCard,
+  Card,
   CardHeader,
   CardBody,
   CardFooter,
@@ -10,21 +10,20 @@ import {
   VStack,
   HStack,
   Text,
-  Heading,
   Alert,
   AlertTitle,
   AlertDescription,
   useColorModeValue,
-  IconButton,
   Image,
   Progress,
   Button,
   Box,
+  Tooltip,
 } from "@chakra-ui/react";
-import { ExternalLinkIcon } from "@chakra-ui/icons";
+import { ExternalLinkIcon, WarningIcon } from "@chakra-ui/icons";
 import Link from "next/link";
-import { calculateDistributionAmounts, formatTokenName } from "@/lib/data/injector/helpers";
-import { colors } from "@/lib/services/chakra/themes/base/colors";
+import { formatTokenName } from "@/lib/data/injector/helpers";
+import { BiTimeFive } from "react-icons/bi";
 
 interface TokenInfo {
   symbol: string;
@@ -47,6 +46,8 @@ interface RewardsInjectorData {
   remaining: number;
   additionalTokensRequired: number;
   incorrectlySetupGauges: string[];
+  hasGaugesNearExpiration?: boolean;
+  hasExpiredGauges?: boolean;
 }
 
 interface RewardsInjectorCardProps {
@@ -67,6 +68,8 @@ const RewardsInjectorCard: React.FC<RewardsInjectorCardProps> = ({ data, network
     remaining,
     additionalTokensRequired,
     incorrectlySetupGauges,
+    hasGaugesNearExpiration,
+    hasExpiredGauges,
   } = data;
 
   const formatAmount = (amount: number | string): string => {
@@ -74,43 +77,97 @@ const RewardsInjectorCard: React.FC<RewardsInjectorCardProps> = ({ data, network
   };
 
   const distributedPercentage = total > 0 ? (distributed / total) * 100 : 0;
-  const remainingPercentage = (remaining / total) * 100;
 
   const explorerUrl = `${network}/${address}?version=${v2 ? "v2" : "v1"}`;
 
   return (
-    <ChakraCard align="center" boxShadow="md" borderRadius="md">
-      <CardHeader w="full">
+    <Card
+      align="center"
+      boxShadow="md"
+      borderRadius="lg"
+      p={{ base: 2, md: 4 }}
+      borderWidth={1}
+      transition="all 0.2s"
+      borderColor={useColorModeValue("gray.100", "whiteAlpha.100")}
+    >
+      <CardHeader w="full" pb={4}>
         <Flex align="center" justify="space-between" w="full">
-          <Flex align="center" gap={2} flex="1">
+          <HStack align="center">
             {networks[network] && (
               <Flex
-                w={10}
-                h={10}
+                w={8}
+                h={8}
                 align="center"
                 justify="center"
                 color="white"
                 rounded="full"
                 flexShrink={0}
+                bg={useColorModeValue("gray.200", "gray.700")}
               >
-                <Image src={networks[network].logo} alt={`${network} logo`} boxSize="18px" />
+                <Image src={networks[network].logo} alt={`${network} logo`} boxSize="24px" />
               </Flex>
             )}
-            <Text size="md" variant="secondary" isTruncated maxWidth="calc(100% - 30px)">
-              {formatTokenName(token)}
-            </Text>
-          </Flex>
-          <IconButton
-            aria-label="View on explorer"
-            as="a"
-            href={explorerUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            size="sm"
-            icon={<ExternalLinkIcon />}
-            variant="ghost"
-            ml="auto"
-          />
+            <VStack align="start" spacing={0}>
+              <HStack spacing={2} align="center">
+                <Link href={`rewards-injector/${address}`} passHref legacyBehavior>
+                  <Text
+                    as="a"
+                    variant="secondary"
+                    fontWeight="bold"
+                    fontSize="lg"
+                    noOfLines={2}
+                    _hover={{ color: "gray.300", textDecoration: "none", cursor: "pointer" }}
+                  >
+                    {formatTokenName(token)}
+                  </Text>
+                </Link>
+              </HStack>
+            </VStack>
+          </HStack>
+          <VStack spacing={2} ml="auto">
+            {hasExpiredGauges && (
+              <Tooltip label="Some gauges are expired and are no longer distributing rewards">
+                <Box
+                  bg="red.500"
+                  color="white"
+                  px={2}
+                  py={0.5}
+                  borderRadius="lg"
+                  cursor="pointer"
+                  display="flex"
+                  alignItems="center"
+                  gap={1}
+                  _hover={{ bg: "red.400" }}
+                >
+                  <BiTimeFive size={14} />
+                  <Text fontSize="xs" fontWeight="medium">
+                    Expired
+                  </Text>
+                </Box>
+              </Tooltip>
+            )}
+            {hasGaugesNearExpiration && (
+              <Tooltip label="Some gauges are about to expire">
+                <Box
+                  bg="yellow.600"
+                  color="white"
+                  px={2}
+                  py={0.5}
+                  borderRadius="lg"
+                  cursor="pointer"
+                  display="flex"
+                  alignItems="center"
+                  gap={1}
+                  _hover={{ bg: "yellow.400" }}
+                >
+                  <WarningIcon boxSize={3} />
+                  <Text fontSize="xs" fontWeight="medium">
+                    Warning
+                  </Text>
+                </Box>
+              </Tooltip>
+            )}
+          </VStack>
         </Flex>
       </CardHeader>
 
@@ -121,17 +178,35 @@ const RewardsInjectorCard: React.FC<RewardsInjectorCardProps> = ({ data, network
             <Text textAlign="right">{tokenInfo.symbol}</Text>
           </HStack>
 
-          <Box>
-            <Text fontWeight="bold" mb={2}>
-              Distribution Progress
-            </Text>
-            <Progress value={distributedPercentage} size="md" colorScheme="green" mb={2} />
-            <HStack justify="space-between">
-              <Text fontSize="sm">
-                {formatAmount(distributed)} / {formatAmount(total)} {tokenInfo.symbol}
-              </Text>
-              <Text fontSize="sm" fontWeight="medium">
-                {distributedPercentage.toFixed(1)}%
+          <Box w="full">
+            <HStack w="full" justify="space-between" mb={1}>
+              <VStack align="start" spacing={0} minW="80px">
+                <Text fontSize="xs" color="gray.400">
+                  Distributed
+                </Text>
+                <Text fontWeight="bold" fontSize="lg">
+                  {formatAmount(distributed)}
+                </Text>
+              </VStack>
+              <VStack align="end" spacing={0} minW="80px">
+                <Text fontSize="xs" color="gray.400">
+                  Remaining
+                </Text>
+                <Text fontWeight="bold" fontSize="lg">
+                  {formatAmount(remaining)}
+                </Text>
+              </VStack>
+            </HStack>
+            <Progress
+              value={distributedPercentage}
+              size="sm"
+              colorScheme="teal"
+              borderRadius="sm"
+              height="3"
+            />
+            <HStack justify="flex-end" w="full" mt={1}>
+              <Text fontSize="sm" color="gray.400">
+                {distributedPercentage.toFixed(1)}% distributed
               </Text>
             </HStack>
           </Box>
@@ -171,7 +246,22 @@ const RewardsInjectorCard: React.FC<RewardsInjectorCardProps> = ({ data, network
       <CardFooter>
         {incorrectlySetupGauges.length > 0 ? (
           <Link href={`rewards-injector/${address}`} legacyBehavior>
-            <Button variant="secondary" rightIcon={<ExternalLinkIcon />}>
+            {/* Create a separate style if needed anywhere else */}
+            <Button
+              as="a"
+              variant="outline"
+              borderColor={useColorModeValue("gray.400", "brown.200")}
+              color={useColorModeValue("gray.700", "brown.100")}
+              rightIcon={<ExternalLinkIcon />}
+              target="_blank"
+              rel="noopener noreferrer"
+              _hover={{
+                bg: useColorModeValue("gray.100", "rgba(230, 198, 160, 0.10)"),
+                borderColor: useColorModeValue("gray.600", "brown.100"),
+                color: useColorModeValue("black", "brown.200"),
+              }}
+              size="md"
+            >
               More Information
             </Button>
           </Link>
@@ -179,17 +269,25 @@ const RewardsInjectorCard: React.FC<RewardsInjectorCardProps> = ({ data, network
           <Link href={explorerUrl} passHref legacyBehavior>
             <Button
               as="a"
-              variant="secondary"
+              variant="outline"
+              borderColor={useColorModeValue("gray.400", "brown.200")}
+              color={useColorModeValue("gray.700", "brown.100")}
               rightIcon={<ExternalLinkIcon />}
               target="_blank"
               rel="noopener noreferrer"
+              _hover={{
+                bg: useColorModeValue("gray.100", "rgba(230, 198, 160, 0.10)"),
+                borderColor: useColorModeValue("gray.600", "brown.100"),
+                color: useColorModeValue("black", "brown.200"),
+              }}
+              size="md"
             >
               View Details
             </Button>
           </Link>
         )}
       </CardFooter>
-    </ChakraCard>
+    </Card>
   );
 };
 

--- a/components/tables/RewardsInjectorTable.tsx
+++ b/components/tables/RewardsInjectorTable.tsx
@@ -108,9 +108,9 @@ export const RewardsInjectorTable: React.FC<RewardsInjectorTableProps> = ({
   const getStatusColor = (status: GaugeStatus) => {
     switch (status) {
       case GaugeStatus.COMPLETED:
-        return { bg: "red.500", hoverBg: "red.400" };
+        return { bg: "red.700", hoverBg: "red.500" };
       case GaugeStatus.WARNING:
-        return { bg: "yellow.600", hoverBg: "yellow.400" };
+        return { bg: "yellow.600", hoverBg: "yellow.500" };
       case GaugeStatus.OK:
       default:
         return { bg: "green.700", hoverBg: "green.600" };

--- a/components/tables/RewardsInjectorTable.tsx
+++ b/components/tables/RewardsInjectorTable.tsx
@@ -17,8 +17,21 @@ import {
   useMediaQuery,
   Badge,
 } from "@chakra-ui/react";
-import { ExternalLinkIcon, TriangleDownIcon, TriangleUpIcon } from "@chakra-ui/icons";
+import {
+  ExternalLinkIcon,
+  TriangleDownIcon,
+  TriangleUpIcon,
+  WarningIcon,
+  CheckCircleIcon,
+} from "@chakra-ui/icons";
+import { BiTimeFive } from "react-icons/bi";
 import { networks } from "@/constants/constants";
+
+export enum GaugeStatus {
+  OK = "OK",
+  COMPLETED = "Completed",
+  WARNING = "Warning",
+}
 
 export interface RewardsInjectorData {
   gaugeAddress: string;
@@ -66,6 +79,43 @@ export const RewardsInjectorTable: React.FC<RewardsInjectorTableProps> = ({
     if (a[sortColumn] > b[sortColumn]) return sortDirection === "asc" ? 1 : -1;
     return 0;
   });
+
+  // Calculate gauge status
+  const getGaugeStatus = (gauge: RewardsInjectorData): GaugeStatus => {
+    const now = Math.floor(Date.now() / 1000);
+    const oneDayInSeconds = 24 * 60 * 60;
+    const twoWeeksAgo = now - 14 * oneDayInSeconds;
+
+    const timestamp = parseInt(gauge.lastInjectionTimeStamp, 10);
+    if (timestamp === 0 || timestamp === null) return GaugeStatus.OK;
+
+    // Check if gauge is expired (last injection was more than 2 weeks ago)
+    if (timestamp > 0 && timestamp < twoWeeksAgo) {
+      return GaugeStatus.COMPLETED;
+    }
+
+    // Check if gauge is approaching expiration (within 48h of reaching 7 days since last injection)
+    const expiryTime = timestamp + 7 * oneDayInSeconds;
+    const timeUntilExpiry = expiryTime - now;
+    if (timeUntilExpiry > 0 && timeUntilExpiry <= 2 * oneDayInSeconds) {
+      return GaugeStatus.WARNING;
+    }
+
+    return GaugeStatus.OK;
+  };
+
+  // Utility to get status colors
+  const getStatusColor = (status: GaugeStatus) => {
+    switch (status) {
+      case GaugeStatus.COMPLETED:
+        return { bg: "red.500", hoverBg: "red.400" };
+      case GaugeStatus.WARNING:
+        return { bg: "yellow.600", hoverBg: "yellow.400" };
+      case GaugeStatus.OK:
+      default:
+        return { bg: "green.700", hoverBg: "green.600" };
+    }
+  };
 
   // Unified date formatter for table view
   const formatTimestamp = (timestamp: string) => {
@@ -136,36 +186,90 @@ export const RewardsInjectorTable: React.FC<RewardsInjectorTableProps> = ({
             <Th>
               <SortableHeader column="lastInjectionTimeStamp" label="Last Injection" />
             </Th>
+
             {isV2 && (
               <Th>
                 <SortableHeader column="doNotStartBeforeTimestamp" label="Starts At" />
               </Th>
             )}
+            <Th>
+              <Text fontWeight="bold" fontSize="sm" textAlign="center">
+                Status
+              </Text>
+            </Th>
           </Tr>
         </Thead>
         <Tbody>
-          {sortedData.map((row, index) => (
-            <Tr key={index}>
-              <Td fontWeight="medium">{row.poolName}</Td>
-              <Td>
-                <AddressLink address={row.gaugeAddress} />
-              </Td>
-              <Td isNumeric>{Number(row.amountPerPeriod).toFixed(2)}</Td>
-              <Td isNumeric>
-                <Badge colorScheme="blue">
-                  {row.periodNumber}/{row.maxPeriods}
-                </Badge>
-              </Td>
-              <Td fontSize="sm">{formatTimestamp(row.lastInjectionTimeStamp)}</Td>
-              {isV2 && (
-                <Td fontSize="sm">
-                  {row.doNotStartBeforeTimestamp
-                    ? formatTimestamp(row.doNotStartBeforeTimestamp)
-                    : "-"}
+          {sortedData.map((row, index) => {
+            const status = getGaugeStatus(row);
+            return (
+              <Tr key={index}>
+                <Td fontWeight="medium">{row.poolName}</Td>
+                <Td>
+                  <AddressLink address={row.gaugeAddress} />
                 </Td>
-              )}
-            </Tr>
-          ))}
+                <Td isNumeric>{Number(row.amountPerPeriod).toFixed(2)}</Td>
+                <Td isNumeric>
+                  <Badge colorScheme="blue">
+                    {row.periodNumber}/{row.maxPeriods}
+                  </Badge>
+                </Td>
+                <Td fontSize="sm">{formatTimestamp(row.lastInjectionTimeStamp)}</Td>
+
+                {isV2 && (
+                  <Td fontSize="sm">
+                    {row.doNotStartBeforeTimestamp
+                      ? formatTimestamp(row.doNotStartBeforeTimestamp)
+                      : "-"}
+                  </Td>
+                )}
+                <Td>
+                  <Flex justify="center">
+                    <Tooltip
+                      label={
+                        status === GaugeStatus.COMPLETED
+                          ? "This gauge is completed and is no longer distributing rewards"
+                          : status === GaugeStatus.WARNING
+                            ? "This gauge is about to expire"
+                            : status === GaugeStatus.OK
+                              ? "This gauge is active and distributing rewards"
+                              : undefined
+                      }
+                    >
+                      {(() => {
+                        const { bg, hoverBg } = getStatusColor(status);
+                        return (
+                          <Box
+                            bg={bg}
+                            color="white"
+                            px={2}
+                            py={0.5}
+                            borderRadius="lg"
+                            cursor="pointer"
+                            display="flex"
+                            alignItems="center"
+                            gap={1}
+                            _hover={{ bg: hoverBg }}
+                          >
+                            {status === GaugeStatus.COMPLETED ? (
+                              <BiTimeFive size={14} />
+                            ) : status === GaugeStatus.WARNING ? (
+                              <WarningIcon boxSize={3} />
+                            ) : status === GaugeStatus.OK ? (
+                              <CheckCircleIcon boxSize={3} />
+                            ) : null}
+                            <Text fontSize="xs" fontWeight="medium">
+                              {status}
+                            </Text>
+                          </Box>
+                        );
+                      })()}
+                    </Tooltip>
+                  </Flex>
+                </Td>
+              </Tr>
+            );
+          })}
         </Tbody>
       </Table>
     </Box>
@@ -173,37 +277,85 @@ export const RewardsInjectorTable: React.FC<RewardsInjectorTableProps> = ({
 
   const mobileLayout = (
     <Box width="100%">
-      {sortedData.map((row, index) => (
-        <Card key={index} p={3} mb={3} borderLeft="4px solid" borderLeftColor="blue.400">
-          <Flex direction="column" gap={2}>
-            <Flex justify="space-between" align="center">
-              <Text fontWeight="bold">{row.poolName}</Text>
-              <Badge colorScheme="blue">
-                {row.periodNumber}/{row.maxPeriods}
-              </Badge>
-            </Flex>
+      {sortedData.map((row, index) => {
+        const status = getGaugeStatus(row);
+        return (
+          <Card key={index} p={3} mb={3} borderLeft="4px solid" borderLeftColor="blue.400">
+            <Flex direction="column" gap={2}>
+              <Flex justify="space-between" align="center">
+                <Text fontWeight="bold">{row.poolName}</Text>
+                <Badge colorScheme="blue">
+                  {row.periodNumber}/{row.maxPeriods}
+                </Badge>
+              </Flex>
 
-            <AddressLink address={row.gaugeAddress} />
+              <AddressLink address={row.gaugeAddress} />
 
-            <HStack justify="space-between">
-              <Text fontSize="sm">Amount:</Text>
-              <Text fontWeight="medium">{`${Number(row.amountPerPeriod).toFixed(2)} ${tokenSymbol}`}</Text>
-            </HStack>
-
-            <HStack justify="space-between">
-              <Text fontSize="sm">Last Injection:</Text>
-              <Text fontSize="sm">{formatTimestamp(row.lastInjectionTimeStamp)}</Text>
-            </HStack>
-
-            {isV2 && row.doNotStartBeforeTimestamp && (
               <HStack justify="space-between">
-                <Text fontSize="sm">Starts At:</Text>
-                <Text fontSize="sm">{formatTimestamp(row.doNotStartBeforeTimestamp)}</Text>
+                <Text fontSize="sm">Amount:</Text>
+                <Text fontWeight="medium">{`${Number(row.amountPerPeriod).toFixed(2)} ${tokenSymbol}`}</Text>
               </HStack>
-            )}
-          </Flex>
-        </Card>
-      ))}
+
+              <HStack justify="space-between">
+                <Text fontSize="sm">Last Injection:</Text>
+                <Text fontSize="sm">{formatTimestamp(row.lastInjectionTimeStamp)}</Text>
+              </HStack>
+
+              {isV2 && row.doNotStartBeforeTimestamp && (
+                <HStack justify="space-between">
+                  <Text fontSize="sm">Starts At:</Text>
+                  <Text fontSize="sm">{formatTimestamp(row.doNotStartBeforeTimestamp)}</Text>
+                </HStack>
+              )}
+              <HStack justify="space-between">
+                <Text fontSize="sm">Status:</Text>
+                <Flex justify="center">
+                  <Tooltip
+                    label={
+                      status === GaugeStatus.COMPLETED
+                        ? "This gauge is completed and is no longer distributing rewards"
+                        : status === GaugeStatus.WARNING
+                          ? "This gauge is about to expire"
+                          : status === GaugeStatus.OK
+                            ? "This gauge is active and distributing rewards"
+                            : undefined
+                    }
+                  >
+                    {(() => {
+                      const { bg, hoverBg } = getStatusColor(status);
+                      return (
+                        <Box
+                          bg={bg}
+                          color="white"
+                          px={2}
+                          py={0.5}
+                          borderRadius="lg"
+                          cursor="pointer"
+                          display="flex"
+                          alignItems="center"
+                          gap={1}
+                          _hover={{ bg: hoverBg }}
+                        >
+                          {status === GaugeStatus.COMPLETED ? (
+                            <BiTimeFive size={14} />
+                          ) : status === GaugeStatus.WARNING ? (
+                            <WarningIcon boxSize={3} />
+                          ) : status === GaugeStatus.OK ? (
+                            <CheckCircleIcon boxSize={3} />
+                          ) : null}
+                          <Text fontSize="xs" fontWeight="medium">
+                            {status}
+                          </Text>
+                        </Box>
+                      );
+                    })()}
+                  </Tooltip>
+                </Flex>
+              </HStack>
+            </Flex>
+          </Card>
+        );
+      })}
     </Box>
   );
 

--- a/lib/services/apollo/generated/graphql.ts
+++ b/lib/services/apollo/generated/graphql.ts
@@ -703,9 +703,13 @@ export type GqlPoolDynamicData = {
   apr: GqlPoolApr;
   aprItems: Array<GqlPoolAprItem>;
   fees24h: Scalars['BigDecimal']['output'];
+  /** @deprecated No longer supported */
   fees24hAth: Scalars['BigDecimal']['output'];
+  /** @deprecated No longer supported */
   fees24hAthTimestamp: Scalars['Int']['output'];
+  /** @deprecated No longer supported */
   fees24hAtl: Scalars['BigDecimal']['output'];
+  /** @deprecated No longer supported */
   fees24hAtlTimestamp: Scalars['Int']['output'];
   fees48h: Scalars['BigDecimal']['output'];
   holdersCount: Scalars['BigInt']['output'];
@@ -719,9 +723,13 @@ export type GqlPoolDynamicData = {
   protocolFees48h: Scalars['BigDecimal']['output'];
   protocolYieldCapture24h: Scalars['BigDecimal']['output'];
   protocolYieldCapture48h: Scalars['BigDecimal']['output'];
+  /** @deprecated No longer supported */
   sharePriceAth: Scalars['BigDecimal']['output'];
+  /** @deprecated No longer supported */
   sharePriceAthTimestamp: Scalars['Int']['output'];
+  /** @deprecated No longer supported */
   sharePriceAtl: Scalars['BigDecimal']['output'];
+  /** @deprecated No longer supported */
   sharePriceAtlTimestamp: Scalars['Int']['output'];
   /** CowAmm specific, equivalent of swap fees */
   surplus24h: Scalars['BigDecimal']['output'];
@@ -733,17 +741,25 @@ export type GqlPoolDynamicData = {
   swapsCount: Scalars['BigInt']['output'];
   totalLiquidity: Scalars['BigDecimal']['output'];
   totalLiquidity24hAgo: Scalars['BigDecimal']['output'];
+  /** @deprecated No longer supported */
   totalLiquidityAth: Scalars['BigDecimal']['output'];
+  /** @deprecated No longer supported */
   totalLiquidityAthTimestamp: Scalars['Int']['output'];
+  /** @deprecated No longer supported */
   totalLiquidityAtl: Scalars['BigDecimal']['output'];
+  /** @deprecated No longer supported */
   totalLiquidityAtlTimestamp: Scalars['Int']['output'];
   totalShares: Scalars['BigDecimal']['output'];
   totalShares24hAgo: Scalars['BigDecimal']['output'];
   totalSupply: Scalars['BigDecimal']['output'];
   volume24h: Scalars['BigDecimal']['output'];
+  /** @deprecated No longer supported */
   volume24hAth: Scalars['BigDecimal']['output'];
+  /** @deprecated No longer supported */
   volume24hAthTimestamp: Scalars['Int']['output'];
+  /** @deprecated No longer supported */
   volume24hAtl: Scalars['BigDecimal']['output'];
+  /** @deprecated No longer supported */
   volume24hAtlTimestamp: Scalars['Int']['output'];
   volume48h: Scalars['BigDecimal']['output'];
   yieldCapture24h: Scalars['BigDecimal']['output'];
@@ -2722,7 +2738,6 @@ export type Mutation = {
   poolSyncAllCowSnapshots: Array<GqlPoolMutationResult>;
   poolSyncAllPoolsFromSubgraph: Array<Scalars['String']['output']>;
   poolSyncFxQuoteTokens: Array<GqlPoolMutationResult>;
-  poolUpdateLifetimeValuesForAllPools: Scalars['String']['output'];
   poolUpdateLiquidityValuesForAllPools: Scalars['String']['output'];
   protocolCacheMetrics: Scalars['String']['output'];
   sftmxSyncStakingData: Scalars['String']['output'];
@@ -2967,10 +2982,16 @@ export type Query = {
   tokenGetTokensDynamicData: Array<GqlTokenDynamicData>;
   userGetFbeetsBalance: GqlUserFbeetsBalance;
   userGetPoolBalances: Array<GqlUserPoolBalance>;
-  /** Will de deprecated in favor of poolGetEvents */
+  /**
+   * Will de deprecated in favor of poolGetEvents
+   * @deprecated Use poolEvents instead
+   */
   userGetPoolJoinExits: Array<GqlPoolJoinExit>;
   userGetStaking: Array<GqlPoolStaking>;
-  /** Will de deprecated in favor of poolGetEvents */
+  /**
+   * Will de deprecated in favor of poolGetEvents
+   * @deprecated Use poolEvents instead
+   */
   userGetSwaps: Array<GqlPoolSwap>;
   veBalGetTotalSupply: Scalars['AmountHumanReadable']['output'];
   veBalGetUser: GqlVeBalUserData;

--- a/lib/services/apollo/generated/schema.graphql
+++ b/lib/services/apollo/generated/schema.graphql
@@ -826,10 +826,10 @@ type GqlPoolDynamicData {
   apr: GqlPoolApr! @deprecated(reason: "Use aprItems instead")
   aprItems: [GqlPoolAprItem!]!
   fees24h: BigDecimal!
-  fees24hAth: BigDecimal!
-  fees24hAthTimestamp: Int!
-  fees24hAtl: BigDecimal!
-  fees24hAtlTimestamp: Int!
+  fees24hAth: BigDecimal! @deprecated
+  fees24hAthTimestamp: Int! @deprecated
+  fees24hAtl: BigDecimal! @deprecated
+  fees24hAtlTimestamp: Int! @deprecated
   fees48h: BigDecimal!
   holdersCount: BigInt!
 
@@ -843,10 +843,10 @@ type GqlPoolDynamicData {
   protocolFees48h: BigDecimal!
   protocolYieldCapture24h: BigDecimal!
   protocolYieldCapture48h: BigDecimal!
-  sharePriceAth: BigDecimal!
-  sharePriceAthTimestamp: Int!
-  sharePriceAtl: BigDecimal!
-  sharePriceAtlTimestamp: Int!
+  sharePriceAth: BigDecimal! @deprecated
+  sharePriceAthTimestamp: Int! @deprecated
+  sharePriceAtl: BigDecimal! @deprecated
+  sharePriceAtlTimestamp: Int! @deprecated
 
   """CowAmm specific, equivalent of swap fees"""
   surplus24h: BigDecimal!
@@ -860,18 +860,18 @@ type GqlPoolDynamicData {
   swapsCount: BigInt!
   totalLiquidity: BigDecimal!
   totalLiquidity24hAgo: BigDecimal!
-  totalLiquidityAth: BigDecimal!
-  totalLiquidityAthTimestamp: Int!
-  totalLiquidityAtl: BigDecimal!
-  totalLiquidityAtlTimestamp: Int!
+  totalLiquidityAth: BigDecimal! @deprecated
+  totalLiquidityAthTimestamp: Int! @deprecated
+  totalLiquidityAtl: BigDecimal! @deprecated
+  totalLiquidityAtlTimestamp: Int! @deprecated
   totalShares: BigDecimal!
   totalShares24hAgo: BigDecimal!
   totalSupply: BigDecimal!
   volume24h: BigDecimal!
-  volume24hAth: BigDecimal!
-  volume24hAthTimestamp: Int!
-  volume24hAtl: BigDecimal!
-  volume24hAtlTimestamp: Int!
+  volume24hAth: BigDecimal! @deprecated
+  volume24hAthTimestamp: Int! @deprecated
+  volume24hAtl: BigDecimal! @deprecated
+  volume24hAtlTimestamp: Int! @deprecated
   volume48h: BigDecimal!
   yieldCapture24h: BigDecimal!
   yieldCapture48h: BigDecimal!
@@ -3112,7 +3112,6 @@ type Mutation {
   poolSyncAllCowSnapshots(chains: [GqlChain!]!): [GqlPoolMutationResult!]!
   poolSyncAllPoolsFromSubgraph: [String!]!
   poolSyncFxQuoteTokens(chains: [GqlChain!]!): [GqlPoolMutationResult!]!
-  poolUpdateLifetimeValuesForAllPools: String!
   poolUpdateLiquidityValuesForAllPools: String!
   protocolCacheMetrics: String!
   sftmxSyncStakingData: String!
@@ -3309,11 +3308,11 @@ type Query {
   userGetPoolBalances(address: String, chains: [GqlChain!]): [GqlUserPoolBalance!]!
 
   """Will de deprecated in favor of poolGetEvents"""
-  userGetPoolJoinExits(address: String, chain: GqlChain, first: Int = 10, poolId: String!, skip: Int = 0): [GqlPoolJoinExit!]!
+  userGetPoolJoinExits(address: String, chain: GqlChain, first: Int = 10, poolId: String!, skip: Int = 0): [GqlPoolJoinExit!]! @deprecated(reason: "Use poolEvents instead")
   userGetStaking(address: String, chains: [GqlChain!]): [GqlPoolStaking!]!
 
   """Will de deprecated in favor of poolGetEvents"""
-  userGetSwaps(address: String, chain: GqlChain, first: Int = 10, poolId: String!, skip: Int = 0): [GqlPoolSwap!]!
+  userGetSwaps(address: String, chain: GqlChain, first: Int = 10, poolId: String!, skip: Int = 0): [GqlPoolSwap!]! @deprecated(reason: "Use poolEvents instead")
   veBalGetTotalSupply(chain: GqlChain): AmountHumanReadable!
   veBalGetUser(address: String!, chain: GqlChain): GqlVeBalUserData!
   veBalGetUserBalance(address: String, chain: GqlChain): AmountHumanReadable!


### PR DESCRIPTION
- Added status labels to the `RewardInjectorCard`:
  - Expired: if injector has any gauge, that last injection time more than 14d from now
  - Warning: if injector has any gauge, where `lastInjectionTimestamp + 7d` is less than 48h from now
- Added status labels to the `RewardsInjectorTable`:
  - Uses `Completed` instead of `Expired`
  - `Warning` label matches the logic used in `RewardInjectorCard`
- UI refresh for injector status board
- Stats view added at the top of the dashboard
- Improved injector loading by parallelizing requests, reducing load time from 15–20s to 2–3s for both v1 and v2