### PR TITLE
fix: fixes distribution calculation

### DIFF
--- a/components/RewardsInjectorConfiguratorV2.tsx
+++ b/components/RewardsInjectorConfiguratorV2.tsx
@@ -7,8 +7,6 @@ import {
   AlertTitle,
   Box,
   Button,
-  Card,
-  CardBody,
   Container,
   Divider,
   Flex,
@@ -109,7 +107,21 @@ function RewardsInjectorConfiguratorV2({
     const newGauges = [...gauges];
     newGauges[index] = { ...updatedGauge, isEdited: true };
     setGauges(newGauges);
-    setEditedGauges(prev => new Set(prev).add(index));
+
+    // Check if this gauge is newly added
+    const isNewlyAdded = newlyAddedGauges.some(newGauge => newGauge.id === updatedGauge.id);
+
+    if (isNewlyAdded) {
+      // Update the gauge in newlyAddedGauges array instead of marking as edited
+      setNewlyAddedGauges(prev =>
+        prev.map(gauge =>
+          gauge.id === updatedGauge.id ? { ...updatedGauge, isEdited: true } : gauge,
+        ),
+      );
+    } else {
+      // Only mark as edited if it's an original gauge
+      setEditedGauges(prev => new Set(prev).add(index));
+    }
 
     toast({
       title: "Configuration Updated",
@@ -179,35 +191,26 @@ function RewardsInjectorConfiguratorV2({
     });
   };
 
-  const calculateCurrentDistribution = (gauges: RewardsInjectorData[]) => {
-    const distribution = gauges.reduce(
-      (acc, gauge) => {
-        const amountPerPeriod = parseFloat(gauge.amountPerPeriod) || 0;
-        const maxPeriods = parseInt(gauge.maxPeriods) || 0;
-        const periodNumber = parseInt(gauge.periodNumber) || 0;
-
-        const gaugeTotal = amountPerPeriod * maxPeriods;
-        const gaugeDistributed = amountPerPeriod * periodNumber;
-        const gaugeRemaining = gaugeTotal - gaugeDistributed;
-
-        return {
-          total: acc.total + gaugeTotal,
-          distributed: acc.distributed + gaugeDistributed,
-          remaining: acc.remaining + gaugeRemaining,
-        };
-      },
-      {
-        total: 0,
-        distributed: 0,
-        remaining: 0,
-      },
-    );
-
-    return distribution;
+  const calculateCurrentTotal = (gauges: RewardsInjectorData[]) => {
+    return gauges.reduce((total, gauge) => {
+      const amountPerPeriod = parseFloat(gauge.amountPerPeriod) || 0;
+      const maxPeriods = parseInt(gauge.maxPeriods) || 0;
+      return total + (amountPerPeriod * maxPeriods);
+    }, 0);
   };
 
-  const calculateNewDistribution = () => {
-    let newDistribution = { total: 0, distributed: 0, remaining: 0 };
+  const calculateCurrentRemaining = (gauges: RewardsInjectorData[]) => {
+    return gauges.reduce((remaining, gauge) => {
+      const amountPerPeriod = parseFloat(gauge.amountPerPeriod) || 0;
+      const maxPeriods = parseInt(gauge.maxPeriods) || 0;
+      const periodNumber = parseInt(gauge.periodNumber) || 0;
+      const gaugeRemaining = (amountPerPeriod * maxPeriods) - (amountPerPeriod * periodNumber);
+      return remaining + gaugeRemaining;
+    }, 0);
+  };
+
+  const calculateNewRemaining = () => {
+    let newRemaining = 0;
 
     // Process each current gauge
     gauges.forEach((gauge, index) => {
@@ -217,50 +220,21 @@ function RewardsInjectorConfiguratorV2({
 
       // Check if this gauge was edited
       if (editedGauges.has(index)) {
-        // For edited gauges: preserve already distributed amount, apply new rate to remaining periods
-        const originalGauge = originalGauges.find(orig => orig.gaugeAddress === gauge.gaugeAddress);
-        if (originalGauge) {
-          const originalAmountPerPeriod = parseFloat(originalGauge.amountPerPeriod) || 0;
-          const originalPeriodNumber = parseInt(originalGauge.periodNumber) || 0;
-          const alreadyDistributed = originalAmountPerPeriod * originalPeriodNumber;
-          const futureDistribution = newAmountPerPeriod * maxPeriods; // New configuration starts fresh
-
-          newDistribution.distributed += alreadyDistributed;
-          newDistribution.remaining += futureDistribution;
-          newDistribution.total += alreadyDistributed + futureDistribution;
-        }
+        // For edited gauges: apply new rate to remaining periods only
+        const futureDistribution = newAmountPerPeriod * maxPeriods; // New configuration starts fresh
+        newRemaining += futureDistribution;
       } else {
         // For non-edited gauges (original or newly added): use standard calculation
-        const gaugeTotal = newAmountPerPeriod * maxPeriods;
-        const gaugeDistributed = newAmountPerPeriod * periodNumber;
-        const gaugeRemaining = gaugeTotal - gaugeDistributed;
-
-        newDistribution.total += gaugeTotal;
-        newDistribution.distributed += gaugeDistributed;
-        newDistribution.remaining += gaugeRemaining;
+        const gaugeRemaining = (newAmountPerPeriod * maxPeriods) - (newAmountPerPeriod * periodNumber);
+        newRemaining += gaugeRemaining;
       }
     });
 
-    // For deleted gauges, we need to preserve the already distributed amount
-    // because those tokens were already distributed and can't be "undistributed"
-    // Use ORIGINAL values for calculating already distributed amount
-    removedGauges.forEach(gauge => {
-      // Find the original gauge to get the correct distributed amount
-      const originalGauge = originalGauges.find(orig => orig.gaugeAddress === gauge.gaugeAddress);
+    // Note: Removed gauges don't contribute to future distribution
+    // Their future distributions are cancelled, so we don't add anything for them
+    // This is correct - removedGauges only affect total distributed amount (not remaining)
 
-      if (originalGauge) {
-        // Use original values for calculating what was already distributed
-        const originalAmountPerPeriod = parseFloat(originalGauge.amountPerPeriod) || 0;
-        const periodNumber = parseInt(originalGauge.periodNumber) || 0;
-        const alreadyDistributed = originalAmountPerPeriod * periodNumber;
-
-        // Only add the distributed amount - future distributions are cancelled
-        newDistribution.distributed += alreadyDistributed;
-        newDistribution.total += alreadyDistributed;
-      }
-    });
-
-    return newDistribution;
+    return newRemaining;
   };
 
   const formatAmount = (amount: number) => {
@@ -270,9 +244,10 @@ function RewardsInjectorConfiguratorV2({
     });
   };
 
-  const currentDistribution = calculateCurrentDistribution(originalGauges);
-  const newDistribution = calculateNewDistribution();
-  const distributionDelta = newDistribution.remaining - currentDistribution.remaining;
+  const currentTotal = calculateCurrentTotal(originalGauges);
+  const currentRemaining = calculateCurrentRemaining(originalGauges);
+  const newRemaining = calculateNewRemaining();
+  const distributionDelta = newRemaining - currentRemaining;
 
   const generatePayload = () => {
     if (!selectedAddress) {
@@ -620,7 +595,7 @@ function RewardsInjectorConfiguratorV2({
                   Current Distribution
                 </Text>
                 <Text fontSize="xl" fontWeight="semibold">
-                  {formatAmount(currentDistribution.total)} {tokenSymbol}
+                  {formatAmount(currentTotal)} {tokenSymbol}
                 </Text>
               </VStack>
               <VStack spacing={1}>
@@ -632,7 +607,7 @@ function RewardsInjectorConfiguratorV2({
                   New Distribution
                 </Text>
                 <Text fontSize="xl" fontWeight="semibold">
-                  {formatAmount(newDistribution.total)} {tokenSymbol}
+                  {formatAmount(newRemaining)} {tokenSymbol}
                 </Text>
               </VStack>
               <VStack spacing={1}>

--- a/components/tables/RewardsInjectorConfiguratorTable.tsx
+++ b/components/tables/RewardsInjectorConfiguratorTable.tsx
@@ -23,6 +23,7 @@ import {
   CardBody,
   Divider,
   FormLabel,
+  useToast,
 } from "@chakra-ui/react";
 import { EditIcon, DeleteIcon, CheckIcon, CloseIcon, AddIcon } from "@chakra-ui/icons";
 import { RewardsInjectorData } from "@/components/tables/RewardsInjectorTable";
@@ -48,6 +49,7 @@ export const RewardsInjectorConfiguratorTable = ({
   onAddRecipient,
   newlyAddedGauges = [],
 }: RewardsInjectorConfiguratorTableProps) => {
+  const toast = useToast();
   const configButtonColor = useColorModeValue("gray.500", "gray.400");
   const configButtonHoverColor = useColorModeValue("gray.600", "gray.300");
   const mutedTextColor = useColorModeValue("gray.600", "gray.400");
@@ -116,8 +118,31 @@ export const RewardsInjectorConfiguratorTable = ({
     setEditingData(updatedGauge);
   };
 
+  const validateGaugeData = (gauge: RewardsInjectorData): string | null => {
+    if (!gauge.gaugeAddress.trim()) {
+      return "Gauge address is required";
+    }
+    if (!gauge.maxPeriods || parseInt(gauge.maxPeriods) <= 0) {
+      return "Max periods must be greater than 0";
+    }
+    return null;
+  };
+
   const handleSave = (index: number) => {
     if (!editingData || !onSaveEdit) return;
+
+    const validationError = validateGaugeData(editingData);
+    if (validationError) {
+      toast({
+        title: "Invalid Input",
+        description: validationError,
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+      return;
+    }
+
     onSaveEdit(index, editingData);
     setEditingIndex(null);
     setEditingData(null);
@@ -151,22 +176,34 @@ export const RewardsInjectorConfiguratorTable = ({
   };
 
   const handleAddRecipient = () => {
-    if (onAddRecipient) {
-      onAddRecipient(newRecipientData);
-      // Reset form and exit add mode
-      setNewRecipientData({
-        gaugeAddress: "",
-        poolName: "",
-        amountPerPeriod: "",
-        rawAmountPerPeriod: "0",
-        periodNumber: "0",
-        maxPeriods: "",
-        isRewardTokenSetup: true,
-        lastInjectionTimeStamp: "0",
-        doNotStartBeforeTimestamp: "0",
+    if (!onAddRecipient) return;
+
+    const validationError = validateGaugeData(newRecipientData);
+    if (validationError) {
+      toast({
+        title: "Invalid Input",
+        description: validationError,
+        status: "error",
+        duration: 5000,
+        isClosable: true,
       });
-      setIsAddingRecipient(false);
+      return;
     }
+
+    onAddRecipient(newRecipientData);
+    // Reset form and exit add mode
+    setNewRecipientData({
+      gaugeAddress: "",
+      poolName: "",
+      amountPerPeriod: "",
+      rawAmountPerPeriod: "0",
+      periodNumber: "0",
+      maxPeriods: "",
+      isRewardTokenSetup: true,
+      lastInjectionTimeStamp: "0",
+      doNotStartBeforeTimestamp: "0",
+    });
+    setIsAddingRecipient(false);
   };
 
   const handleCancelAdd = () => {


### PR DESCRIPTION
After Zekraken's feedback, decided to simplify calculations to calculate only the things we care about and show:

- **Current Distribution**: Total distributed + remaining from originally configured gauges
- **New Distribution**: Preview of distribution after pending gauge changes
- **Distribution Delta**: Difference between new and current remaining amounts

*Note: These changes only affect the statistics display - payload generation and core logic remain unchanged.*

Squeezed in some small UI fixes:
- Added recipient validation: prevents saving rows with empty addresses or non-positive periods
- Fixed `editedGauges` array logic: newly added and later edited configurations are no longer incorrectly tracked as edited gauges.