### PR TITLE
Composer fixes

### DIFF
--- a/app/payload-builder/composer/ComposerPayloadViewer.tsx
+++ b/app/payload-builder/composer/ComposerPayloadViewer.tsx
@@ -89,10 +89,20 @@ export default function ComposerPayloadViewer({
     const networkName = networkOption?.label;
     const networkPath = networkName === "Ethereum" ? "Mainnet" : networkName;
 
-    // Create descriptive title based on operations
-    const operationTitles = operations.map(op => op.title || op.type).slice(0, 3);
-    const titleSuffix = operations.length > 3 ? ` (+${operations.length - 3} more)` : "";
-    const combinedTitle = operationTitles.join(", ") + titleSuffix;
+    // Create descriptive title based on operations, grouping duplicates
+    const operationCounts = new Map<string, number>();
+    operations.forEach(op => {
+      const title = op.title || op.type;
+      operationCounts.set(title, (operationCounts.get(title) || 0) + 1);
+    });
+    
+    const uniqueTitles = Array.from(operationCounts.entries())
+      .map(([title, count]) => count > 1 ? `${title} (${count}x)` : title)
+      .slice(0, 3);
+    
+    const remainingCount = Math.max(0, operationCounts.size - 3);
+    const titleSuffix = remainingCount > 0 ? ` (+${remainingCount} more)` : "";
+    const combinedTitle = uniqueTitles.join(", ") + titleSuffix;
 
     // Create description
     const operationsList = operations

--- a/constants/constants.ts
+++ b/constants/constants.ts
@@ -542,6 +542,7 @@ export const WHITELISTED_PAYMENT_TOKENS: { [network: string]: TokenInfo[] } = {
   ],
 };
 
+// Constants for V2 Pool Creator
 // TODO: import from address book
 export const FactoryAddressWeighted = {
   MAINNET: "0x897888115Ada5773E02aA29F775430BFB5F34c51",
@@ -555,6 +556,7 @@ export const FactoryAddressWeighted = {
   FRAXTAL: "0x9dA18982a33FD0c7051B19F0d7C76F2d5E7e017c",
   MODE: "0xc3ccacE87f6d3A81724075ADcb5ddd85a8A1bB68",
   SEPOLIA: "0x7920BFa1b2041911b354747CA7A6cDD2dfC50Cfd",
+  HYPEREVM: "", // placeholder, V2 is not deployed on HyperEVM
 };
 export const FactoryAddressComposable = {
   MAINNET: "0x5B42eC6D40f7B7965BE5308c70e2603c0281C1E9",
@@ -568,6 +570,7 @@ export const FactoryAddressComposable = {
   FRAXTAL: "0x4bdCc2fb18AEb9e2d281b0278D946445070EAda7",
   MODE: "0x5DbAd78818D4c8958EfF2d5b95b28385A22113Cd",
   SEPOLIA: "0x05503B3aDE04aCA81c8D6F88eCB73Ba156982D2B",
+  HYPEREVM: "", // placeholder, V2 is not deployed on HyperEVM
 };
 
 // Single static factory, easier to store here than fetch from address book

--- a/lib/utils/getNetworkString.ts
+++ b/lib/utils/getNetworkString.ts
@@ -18,6 +18,8 @@ export const getNetworkString = (chainId?: number) => {
       return "MODE";
     case 100:
       return "GNOSIS";
+    case 999:
+      return "HYPEREVM";
     case 11155111:
       return "SEPOLIA";
     default:


### PR DESCRIPTION
**Network Support**
- Added HyperEVM to the `chainId => networkString` mapping

**Payload Composer title fix**
- Grouped duplicate operations to create cleaner, more readable PR titles
- Added operation counters to reduce title length and improve clarity

**Examples:**

*Before:*
```
Combined Payload: Configure StableSurge Hook, Configure StableSurge Hook, Configure StableSurge Hook (+6 more)
```

*After:*
```
Combined Payload: Configure StableSurge Hook (9x)
```

*Multiple operation types:*
```
Combined Payload: Configure StableSurge Hook (3x), Change Swap Fee (v3) (4x), Configure MEV Capture Hook (+1 more)
```

**Behavior:** Shows counters for the first three operation types, with remaining operations summarized as "(+N more)" when applicable.