### PR TITLE
Fix network selectors

### DIFF
--- a/app/payload-builder/add-reward-to-gauge/page.tsx
+++ b/app/payload-builder/add-reward-to-gauge/page.tsx
@@ -114,7 +114,10 @@ export default function AddRewardToGaugePage() {
     }
   };
 
-  const filteredNetworkOptions = NETWORK_OPTIONS.filter(network => network.apiID !== "SONIC");
+  const filteredNetworkOptions = NETWORK_OPTIONS.filter(
+    network =>
+      network.apiID !== "SONIC" && network.apiID !== "PLASMA" && network.apiID !== "HYPEREVM",
+  );
 
   const handleNetworkChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const selectedApiID = e.target.value;

--- a/app/payload-builder/enable-gauge/page.tsx
+++ b/app/payload-builder/enable-gauge/page.tsx
@@ -100,7 +100,10 @@ export default function EnableGaugePage() {
       apiID, // Using the key directly
       chainId: "0", // Default chainId
     }))
-    .filter(network => network.apiID !== "sonic");
+    .filter(
+      network =>
+        network.apiID !== "sonic" && network.apiID !== "plasma" && network.apiID !== "hyperevm",
+    );
 
   // Prepare pre-filled values for PR modal
   const getPrefillValues = () => {

--- a/app/payload-builder/set-reward-distributor-to-gauge/page.tsx
+++ b/app/payload-builder/set-reward-distributor-to-gauge/page.tsx
@@ -107,7 +107,10 @@ export default function SetRewardDistributorPage() {
     }
   };
 
-  const filteredNetworkOptions = NETWORK_OPTIONS.filter(network => network.apiID !== "SONIC");
+  const filteredNetworkOptions = NETWORK_OPTIONS.filter(
+    network =>
+      network.apiID !== "SONIC" && network.apiID !== "PLASMA" && network.apiID !== "HYPEREVM",
+  );
 
   const handleNetworkChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const selectedApiID = e.target.value;

--- a/components/CreateGaugeModule.tsx
+++ b/components/CreateGaugeModule.tsx
@@ -105,7 +105,10 @@ export default function CreateGaugeModule({ addressBook }: CreateGaugeProps) {
 
   //Chain state switch
   const { switchChain } = useSwitchChain();
-  const filteredNetworkOptions = NETWORK_OPTIONS.filter(network => network.apiID !== "SONIC");
+  const filteredNetworkOptions = NETWORK_OPTIONS.filter(
+    network =>
+      network.apiID !== "SONIC" && network.apiID !== "PLASMA" && network.apiID !== "HYPEREVM",
+  );
 
   //Pool data
   const { loading, error, data } = useQuery<GetPoolsQuery, GetPoolsQueryVariables>(

--- a/components/InjectorCreatorModule.tsx
+++ b/components/InjectorCreatorModule.tsx
@@ -136,6 +136,15 @@ const convertToHumanReadable = (rawAmount: string, decimals: number): string => 
   }
 };
 
+const filteredNetworkOptions = NETWORK_OPTIONS.filter(
+  network =>
+    network.apiID !== "SONIC" &&
+    network.apiID !== "PLASMA" &&
+    network.apiID !== "HYPEREVM" &&
+    network.apiID !== "MODE" &&
+    network.apiID !== "FRAXTAL",
+);
+
 export default function InjectorCreatorModule({ addressBook }: InjectorCreationProps) {
   const [selectedNetwork, setSelectedNetwork] = useState("");
   const [factoryAddress, setFactoryAddress] = useState("");
@@ -898,7 +907,7 @@ export default function InjectorCreatorModule({ addressBook }: InjectorCreationP
         <GridItem colSpan={{ base: 12, md: 4 }}>
           <NetworkSelector
             networks={networks}
-            networkOptions={NETWORK_OPTIONS}
+            networkOptions={filteredNetworkOptions}
             selectedNetwork={selectedNetwork}
             handleNetworkChange={handleNetworkChange}
           />

--- a/lib/services/apollo/generated/graphql.ts
+++ b/lib/services/apollo/generated/graphql.ts
@@ -212,10 +212,6 @@ export type GqlLatestSyncedBlocks = {
 
 export type GqlLoopsData = {
   __typename: 'GqlLoopsData';
-  /** Aave Merit APR */
-  aaveMeritApr: Scalars['Float']['output'];
-  /** Aave S borrow APR */
-  aaveSBorrowApr: Scalars['Float']['output'];
   /** Actual TotalSupply of LoopS. */
   actualSupply: Scalars['String']['output'];
   /** The total APR for LoopS */
@@ -230,20 +226,18 @@ export type GqlLoopsData = {
   healthFactor: Scalars['String']['output'];
   /** The amount of leverage the current position has. */
   leverage: Scalars['Float']['output'];
-  /** Loan To Value of the position */
-  ltv: Scalars['String']['output'];
   /** Net Asset Value. The amount of collateral minus the amount of debt. */
   nav: Scalars['String']['output'];
   /** The current rate of LoopS against S. */
   rate: Scalars['String']['output'];
   /** The current Sonic points multiplier for LoopS */
   sonicPointsMultiplier: Scalars['String']['output'];
-  /** The current cap on the stS market on Aave */
-  stSAaveMarketCap: Scalars['String']['output'];
-  /** The max LTV of the market with e-mode */
-  stSAaveMarketMaxLTV: Scalars['String']['output'];
   /** The current amount of stS supplied to the Aave market */
   stSAaveMarketSupply: Scalars['String']['output'];
+  /** The current cap on the stS market on Aave */
+  stSAaveMarketSupplyCap: Scalars['String']['output'];
+  /** Net Asset Value in USD. */
+  tvl: Scalars['String']['output'];
 };
 
 /** All info on the nested pool if the token is a BPT. It will only support 1 level of nesting. */

--- a/lib/services/apollo/generated/schema.graphql
+++ b/lib/services/apollo/generated/schema.graphql
@@ -188,12 +188,6 @@ type GqlLatestSyncedBlocks {
 }
 
 type GqlLoopsData {
-  """Aave Merit APR"""
-  aaveMeritApr: Float!
-
-  """Aave S borrow APR"""
-  aaveSBorrowApr: Float!
-
   """Actual TotalSupply of LoopS."""
   actualSupply: String!
 
@@ -215,9 +209,6 @@ type GqlLoopsData {
   """The amount of leverage the current position has."""
   leverage: Float!
 
-  """Loan To Value of the position"""
-  ltv: String!
-
   """Net Asset Value. The amount of collateral minus the amount of debt."""
   nav: String!
 
@@ -227,14 +218,14 @@ type GqlLoopsData {
   """The current Sonic points multiplier for LoopS"""
   sonicPointsMultiplier: String!
 
-  """The current cap on the stS market on Aave"""
-  stSAaveMarketCap: String!
-
-  """The max LTV of the market with e-mode"""
-  stSAaveMarketMaxLTV: String!
-
   """The current amount of stS supplied to the Aave market"""
   stSAaveMarketSupply: String!
+
+  """The current cap on the stS market on Aave"""
+  stSAaveMarketSupplyCap: String!
+
+  """Net Asset Value in USD."""
+  tvl: String!
 }
 
 """

--- a/package.json
+++ b/package.json
@@ -129,6 +129,5 @@
     "rules": {
       "prettier/prettier": "error"
     }
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -129,5 +129,6 @@
     "rules": {
       "prettier/prettier": "error"
     }
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
Some network selectors had an incorrect subset of supported chains configured (all by default). 
This PR removes those. It is a simple solution for now although we could do more sophisticated checks in the future where we validate deployed contracts for a given chain. For now this is enough and serves our purpose.

closes #189 