### PR TITLE
Fix: Address check endpoint

### DIFF
--- a/app/api/address-check/route.ts
+++ b/app/api/address-check/route.ts
@@ -3,7 +3,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { networks } from "@/constants/constants";
 import { AddressType } from "@/types/interfaces";
 
-const safeAbi = ["function VERSION() external view returns (string)"];
+// Safe-specific ABI - must have all these functions to be considered a Safe
+const safeAbi = [
+  "function VERSION() external view returns (string)",
+  "function getOwners() external view returns (address[])",
+  "function getThreshold() external view returns (uint256)",
+];
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
@@ -24,6 +29,8 @@ export async function GET(request: NextRequest) {
   try {
     // First check if it has code (EOA vs contract)
     const code = await provider.getCode(address);
+
+    // No code = regular EOA
     if (code === "0x" || code === "0x0") {
       return NextResponse.json({
         address,
@@ -31,17 +38,41 @@ export async function GET(request: NextRequest) {
       });
     }
 
-    // Try to call Safe-specific functions
+    // EIP-7702 delegated EOA: starts with 0xef0100 followed by 20-byte delegate address
+    // Format: 0xef0100 + <20-byte address> = 0xef0100 + 40 hex chars = 46 chars total (+ "0x" prefix = 48)
+    if (code.toLowerCase().startsWith("0xef0100") && code.length === 48) {
+      return NextResponse.json({
+        address,
+        type: AddressType.EOA,
+      });
+    }
+
+    // Try to call multiple Safe-specific functions to confirm it's a Safe
+    // VERSION() alone is not enough as many contracts have this function
     const contract = new ethers.Contract(address, safeAbi, provider);
 
     try {
-      await contract.VERSION();
+      // All three calls must succeed for it to be considered a Safe
+      const [version, owners, threshold] = await Promise.all([
+        contract.VERSION(),
+        contract.getOwners(),
+        contract.getThreshold(),
+      ]);
 
+      // Additional validation: Safe must have at least one owner and threshold >= 1
+      if (owners.length > 0 && threshold >= BigInt(1)) {
+        return NextResponse.json({
+          address,
+          type: AddressType.SAFE_PROXY,
+        });
+      }
+
+      // Has VERSION but not valid Safe configuration
       return NextResponse.json({
         address,
-        type: AddressType.SAFE_PROXY,
+        type: AddressType.CONTRACT,
       });
-    } catch (safeError) {
+    } catch {
       // Not a Safe contract, but still a contract
       return NextResponse.json({
         address,

--- a/lib/services/apollo/generated/graphql.ts
+++ b/lib/services/apollo/generated/graphql.ts
@@ -732,6 +732,7 @@ export type GqlPoolDynamicData = {
   /** Disabled for bricked pools */
   swapEnabled: Scalars['Boolean']['output'];
   swapFee: Scalars['BigDecimal']['output'];
+  /** @deprecated No longer supported */
   swapsCount: Scalars['BigInt']['output'];
   totalLiquidity: Scalars['BigDecimal']['output'];
   totalLiquidity24hAgo: Scalars['BigDecimal']['output'];
@@ -2829,7 +2830,6 @@ export type MevTaxHookParams = {
 export type Mutation = {
   __typename: 'Mutation';
   beetsPoolLoadReliquarySnapshotsForAllFarms: Scalars['String']['output'];
-  beetsSyncFbeetsRatio: Scalars['String']['output'];
   createLBP: Scalars['Boolean']['output'];
   poolLoadOnChainDataForAllPools: Array<GqlPoolMutationResult>;
   poolLoadSnapshotsForPools: Scalars['String']['output'];

--- a/lib/services/apollo/generated/schema.graphql
+++ b/lib/services/apollo/generated/schema.graphql
@@ -864,7 +864,7 @@ type GqlPoolDynamicData {
   """Disabled for bricked pools"""
   swapEnabled: Boolean!
   swapFee: BigDecimal!
-  swapsCount: BigInt!
+  swapsCount: BigInt! @deprecated
   totalLiquidity: BigDecimal!
   totalLiquidity24hAgo: BigDecimal!
   totalLiquidityAth: BigDecimal! @deprecated
@@ -3218,7 +3218,6 @@ type MevTaxHookParams {
 
 type Mutation {
   beetsPoolLoadReliquarySnapshotsForAllFarms(chain: GqlChain!): String!
-  beetsSyncFbeetsRatio: String!
   createLBP(input: CreateLBPInput!): Boolean!
   poolLoadOnChainDataForAllPools(chains: [GqlChain!]!): [GqlPoolMutationResult!]!
   poolLoadSnapshotsForPools(chain: GqlChain!, poolId: String!): String!


### PR DESCRIPTION
Fixes incorrect address type detection in the /api/address-check endpoint.

  Issues Fixed:
  - EIP-7702 delegated EOAs were misidentified as Safe proxies - EOAs using the new Pectra delegation feature (bytecode starting with 0xef0100) were incorrectly classified because they have bytecode and their delegate contract has a VERSION() function
  - VERSION() check was too permissive - Many contracts have a VERSION() function, not just Safe proxies

  Changes:
  1. Added detection for EIP-7702 delegated EOAs (bytecode pattern 0xef0100 + 20-byte delegate address)
  2. Safe detection now requires all three Safe-specific functions to succeed:
    - VERSION()
    - getOwners()
    - getThreshold()
  3. Added validation that Safe has owners.length > 0 and threshold >= 1