### PR TITLE
Scrolling fix

### DIFF
--- a/public/css/global.css
+++ b/public/css/global.css
@@ -16,7 +16,7 @@ html,
 body {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    overscroll-behavior: none;
+    overscroll-behavior: auto;
     overflow-x: hidden;
 }
 


### PR DESCRIPTION
The scrolling behavior broke after upgrading to Chromium 144 in Chrome/Brave. [The update](https://developer.chrome.com/release-notes/144?hl=en#respect_overscroll-behavior_on_non-scrollable_scroll_containers) began enforcing the `overscroll-behavior` property on non-scrollable containers, turning our layout wrappers into scroll traps. This PR resets those properties in our styles so that scroll events will propagate to the body again, restoring normal scrolling.

I tested the app, nothing broke imo, but please test again.