### PR TITLE
fix: fixes floating point precision in very small numbers

### DIFF
--- a/app/payload-builder/payloadHelperFunctions.ts
+++ b/app/payload-builder/payloadHelperFunctions.ts
@@ -1,4 +1,8 @@
-import { SPARK_USDS_PSM_WRAPPER_ADDRESS, V3_VAULT_ADDRESS, WHITELISTED_PAYMENT_TOKENS } from "@/constants/constants";
+import {
+  SPARK_USDS_PSM_WRAPPER_ADDRESS,
+  V3_VAULT_ADDRESS,
+  WHITELISTED_PAYMENT_TOKENS,
+} from "@/constants/constants";
 import { BatchFile, Transaction } from "@/components/btns/SimulateTransactionButton";
 import { addDays } from "date-fns";
 import { ethers, JsonRpcSigner, parseUnits } from "ethers";
@@ -653,7 +657,7 @@ export function generateSwapFeeChangePayload(
   chainId: string,
   multisig: string,
 ) {
-  const swapFeePercentage = (parseFloat(input.newSwapFeePercentage) * 1e16).toString(); // Convert to wei format
+  const swapFeePercentage = percentageToWei(input.newSwapFeePercentage);
 
   const transaction = {
     to: input.poolAddress,
@@ -697,7 +701,7 @@ export function generateGauntletSwapFeeChangePayload(
 ) {
   // Default Gauntlet fee setter address for mainnet if not provided
   const feeSetterAddress = gauntletFeeSetterAddress || "0xE4a8ed6c1D8d048bD29A00946BFcf2DB10E7923B";
-  const swapFeePercentage = (parseFloat(input.newSwapFeePercentage) * 1e16).toString();
+  const swapFeePercentage = percentageToWei(input.newSwapFeePercentage);
 
   const transaction = {
     to: feeSetterAddress,
@@ -746,7 +750,7 @@ export function isZeroAddress(address: string): boolean {
 
 // Convert percentage to wei format (e.g., 0.1% -> 1000000000000000)
 export function percentageToWei(percentage: string): string {
-  return (parseFloat(percentage) * 1e16).toString();
+  return parseUnits(percentage, 16).toString();
 }
 
 // Generate payload for DAO-governed pools (swapFeeManager is zero address)
@@ -2099,7 +2103,6 @@ export function generateSparkPSMDepositPayload(input: SparkPSMDepositInput) {
     transactions,
   };
 }
-
 
 export interface SparkPSMWithdrawInput {
   inTokenAddress: string;

--- a/app/payload-builder/simulationHelperFunctions.ts
+++ b/app/payload-builder/simulationHelperFunctions.ts
@@ -385,7 +385,7 @@ export function buildStableSurgeParameterSimulationTransactions(
     const transactions: SimulationTransaction[] = [];
 
     if (hasMaxSurgeFeePercentage && maxSurgeFeePercentage) {
-      const maxSurgeFeeValue = BigInt(parseFloat(maxSurgeFeePercentage) * 1e16).toString();
+      const maxSurgeFeeValue = ethers.parseUnits(maxSurgeFeePercentage, 16).toString();
 
       const data = contract.interface.encodeFunctionData("setMaxSurgeFeePercentage", [
         selectedPool.address,
@@ -400,7 +400,7 @@ export function buildStableSurgeParameterSimulationTransactions(
     }
 
     if (hasSurgeThresholdPercentage && surgeThresholdPercentage) {
-      const surgeThresholdValue = BigInt(parseFloat(surgeThresholdPercentage) * 1e16).toString();
+      const surgeThresholdValue = ethers.parseUnits(surgeThresholdPercentage, 16).toString();
 
       const data = contract.interface.encodeFunctionData("setSurgeThresholdPercentage", [
         selectedPool.address,
@@ -492,15 +492,12 @@ export function buildChangeProtocolFeeV3SimulationTransactions(
   if (!selectedPool || !protocolFeeControllerAddress) return null;
 
   try {
-    const contract = new ethers.Contract(
-      protocolFeeControllerAddress,
-      protocolFeeControllerAbi,
-    );
+    const contract = new ethers.Contract(protocolFeeControllerAddress, protocolFeeControllerAbi);
     const transactions: SimulationTransaction[] = [];
 
     if (hasProtocolSwapFee && protocolSwapFeePercentage) {
       // Convert percentage to 18-decimal format (e.g., 25% -> 250000000000000000)
-      const protocolSwapFeeValue = BigInt(parseFloat(protocolSwapFeePercentage) * 1e16).toString();
+      const protocolSwapFeeValue = ethers.parseUnits(protocolSwapFeePercentage, 16).toString();
 
       const data = contract.interface.encodeFunctionData("setProtocolSwapFeePercentage", [
         selectedPool.address,
@@ -516,7 +513,7 @@ export function buildChangeProtocolFeeV3SimulationTransactions(
 
     if (hasProtocolYieldFee && protocolYieldFeePercentage) {
       // Convert percentage to 18-decimal format (e.g., 25% -> 250000000000000000)
-      const protocolYieldFeeValue = BigInt(parseFloat(protocolYieldFeePercentage) * 1e16).toString();
+      const protocolYieldFeeValue = ethers.parseUnits(protocolYieldFeePercentage, 16).toString();
 
       const data = contract.interface.encodeFunctionData("setProtocolYieldFeePercentage", [
         selectedPool.address,

--- a/components/StableSurgeHookConfigurationModule.tsx
+++ b/components/StableSurgeHookConfigurationModule.tsx
@@ -383,9 +383,9 @@ export default function StableSurgeHookConfigurationModule({
 
         // Update max surge fee if provided
         if (debouncedMaxSurgeFeePercentage) {
-          const txMaxSurgeFeePercentage = BigInt(
-            parseFloat(debouncedMaxSurgeFeePercentage) * 1e16,
-          ).toString();
+          const txMaxSurgeFeePercentage = ethers
+            .parseUnits(debouncedMaxSurgeFeePercentage, 16)
+            .toString();
           const tx1 = await hookContract.setMaxSurgeFeePercentage(
             selectedPool.address,
             txMaxSurgeFeePercentage,
@@ -414,9 +414,9 @@ export default function StableSurgeHookConfigurationModule({
 
         // Update surge threshold if provided
         if (debouncedSurgeThresholdPercentage) {
-          const txSurgeThresholdPercentage = BigInt(
-            parseFloat(debouncedSurgeThresholdPercentage) * 1e16,
-          ).toString();
+          const txSurgeThresholdPercentage = ethers
+            .parseUnits(debouncedSurgeThresholdPercentage, 16)
+            .toString();
           const tx2 = await hookContract.setSurgeThresholdPercentage(
             selectedPool.address,
             txSurgeThresholdPercentage,

--- a/lib/services/apollo/generated/graphql.ts
+++ b/lib/services/apollo/generated/graphql.ts
@@ -94,6 +94,7 @@ export enum GqlChain {
   Hyperevm = 'HYPEREVM',
   Mainnet = 'MAINNET',
   Mode = 'MODE',
+  Monad = 'MONAD',
   Optimism = 'OPTIMISM',
   Plasma = 'PLASMA',
   Polygon = 'POLYGON',

--- a/lib/services/apollo/generated/schema.graphql
+++ b/lib/services/apollo/generated/schema.graphql
@@ -87,6 +87,7 @@ enum GqlChain {
   HYPEREVM
   MAINNET
   MODE
+  MONAD
   OPTIMISM
   PLASMA
   POLYGON


### PR DESCRIPTION
Percentage values in `ChangeSwapFeeModule`, `ChangeSwapFeeV3Module`, `StableSurgeHookConfigurationModule`, `ChangeProtocolFeeV3Module` were calculated incorrectly using `parseFloat(percentage) * 1e16`.

**Example of the bug:**
```javascript
parseFloat("0.0006") * 1e16  // 5999999999999.999 ❌ (should be 6000000000000)
```

This was tricky, because `0.0005` or `0.0007` worked fine, there were only some cases where rounding overflew and it blew up.

Replaced all manual conversions with `ethers.parseUnits(percentage, 16)` and it's all good now.