### PR TITLE
Security upgrades Feb 5th

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "graphql-request": "^6.1.0",
     "graphql-tag": "^2.12.6",
     "limiter": "^2.1.0",
-    "lodash": "^4.17.21",
+    "lodash": "^4.17.23",
     "next": "15.5.10",
     "next-auth": "^4.24.12",
     "next-themes": "^0.3.0",
@@ -119,7 +119,8 @@
     "cookie": "^0.7.0",
     "js-yaml": "^4.1.1",
     "h3": "^1.15.5",
-    "hono": "^4.11.4"
+    "lodash": "^4.17.23",
+    "hono": "^4.11.7"
   },
   "eslintConfig": {
     "extends": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -7561,10 +7561,10 @@ hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   dependencies:
     react-is "^16.7.0"
 
-hono@^4.10.3, hono@^4.11.4:
-  version "4.11.4"
-  resolved "https://registry.yarnpkg.com/hono/-/hono-4.11.4.tgz#0c1ba7175e08624932224bc7644e4cb22b294080"
-  integrity sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==
+hono@^4.10.3, hono@^4.11.7:
+  version "4.11.7"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-4.11.7.tgz#f5b8d0b0b503ef0d913a246012dda52ea23dbe53"
+  integrity sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==
 
 html-escaper@^2.0.2:
   version "2.0.2"
@@ -8462,10 +8462,10 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==
 
-lodash@^4.17.20, lodash@^4.17.21, lodash@~4.17.0:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.23, lodash@~4.17.0:
+  version "4.17.23"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
+  integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
 
 log-symbols@^4.0.0, log-symbols@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
Patches security vulnerabilities for:

  lodash: Updated from 4.17.21 → 4.17.23
  - Direct dependency updated in package.json
  - Added to resolutions to ensure all transitive dependencies use the secure version

  hono: Updated from 4.11.4 → 4.11.7
  - Resolution updated in package.json

NOTE: next.js upgrades will be done separately