### PR TITLE
chore: bake chainIds into filenames for auto-queue action

### DIFF
--- a/app/payload-builder/add-reward-to-gauge/page.tsx
+++ b/app/payload-builder/add-reward-to-gauge/page.tsx
@@ -241,7 +241,9 @@ export default function AddRewardToGaugePage() {
     }
 
     // Just provide the filename portion - let the modal combine it with the path from config
-    const filename = `add-rewards-${shortGaugeId}-${uniqueId}.json`;
+    const chainIds = Array.from(new Set(rewardAdds.map(r => r.chainId)));
+    const chainSlug = chainIds.length === 1 ? chainIds[0] : "multi";
+    const filename = `add-rewards-${chainSlug}-${shortGaugeId}-${uniqueId}.json`;
 
     return {
       prefillBranchName: `feature/add-rewards-${shortGaugeId}-${uniqueId}`,

--- a/app/payload-builder/composer/ComposerPayloadViewer.tsx
+++ b/app/payload-builder/composer/ComposerPayloadViewer.tsx
@@ -88,6 +88,7 @@ export default function ComposerPayloadViewer({
     const networkOption = NETWORK_OPTIONS.find(n => n.apiID === primaryNetwork);
     const networkName = networkOption?.label;
     const networkPath = networkName === "Ethereum" ? "Mainnet" : networkName;
+    const chainId = networkOption?.chainId || primaryNetwork;
 
     // Create descriptive title based on operations, grouping duplicates
     const operationCounts = new Map<string, number>();
@@ -116,7 +117,7 @@ export default function ComposerPayloadViewer({
       prefillBranchName: `feature/combined-operations-${uniqueId}`,
       prefillPrName: `Combined Payload: ${combinedTitle}`,
       prefillDescription: `This PR combines ${operations.length} operations into a single transaction on ${networkName}:\n\n${operationsList}`,
-      prefillFilename: `${networkPath}/combined-operations-${uniqueId}.json`,
+      prefillFilename: `combined-operations-${chainId}-${uniqueId}.json`,
     };
   };
 

--- a/app/payload-builder/set-reward-distributor-to-gauge/page.tsx
+++ b/app/payload-builder/set-reward-distributor-to-gauge/page.tsx
@@ -234,7 +234,9 @@ export default function SetRewardDistributorPage() {
     }
 
     // Just provide the filename portion - let the modal combine it with the path from config
-    const filename = `set-distributors-${shortGaugeId}-${uniqueId}.json`;
+    const chainIds = Array.from(new Set(rewardAdds.map(r => r.chainId)));
+    const chainSlug = chainIds.length === 1 ? chainIds[0] : "multi";
+    const filename = `set-distributors-${chainSlug}-${shortGaugeId}-${uniqueId}.json`;
 
     return {
       prefillBranchName: `feature/set-distributor-${shortGaugeId}-${uniqueId}`,

--- a/components/ChangeAmpFactorModule.tsx
+++ b/components/ChangeAmpFactorModule.tsx
@@ -311,8 +311,9 @@ export default function ChangeAmpFactorModule({
     const networkOption = NETWORK_OPTIONS.find(n => n.apiID === selectedNetwork);
     const networkName = networkOption?.label || selectedNetwork;
     const networkPath = networkName === "Ethereum" ? "Mainnet" : networkName;
+    const chainId = networkOption?.chainId || selectedNetwork;
 
-    const filename = networkPath + `/amp-factor-update-${selectedPool.address}-${uniqueId}.json`;
+    const filename = `amp-factor-update-${chainId}-${selectedPool.address}-${uniqueId}.json`;
 
     return {
       prefillBranchName: `feature/amp-factor-${shortPoolId}-${uniqueId}`,

--- a/components/ChangeProtocolFeeV3Module.tsx
+++ b/components/ChangeProtocolFeeV3Module.tsx
@@ -373,8 +373,9 @@ export default function ChangeProtocolFeeV3Module({ addressBook }: { addressBook
     const networkOption = NETWORK_OPTIONS.find(n => n.apiID === selectedNetwork);
     const networkName = networkOption?.label || selectedNetwork;
     const networkPath = networkName === "Ethereum" ? "Mainnet" : networkName;
+    const chainId = networkOption?.chainId || selectedNetwork;
 
-    const filename = networkPath + `/set-protocol-fee-${selectedPool.address}-${uniqueId}.json`;
+    const filename = `set-protocol-fee-${chainId}-${selectedPool.address}-${uniqueId}.json`;
 
     return {
       prefillBranchName: `feature/protocol-fee-${shortPoolId}-${uniqueId}`,

--- a/components/ChangeSwapFeeModule.tsx
+++ b/components/ChangeSwapFeeModule.tsx
@@ -109,9 +109,10 @@ export default function ChangeSwapFeeModule({ addressBook }: ChangeSwapFeeProps)
     const networkOption = NETWORK_OPTIONS.find(n => n.apiID === selectedNetwork);
     const networkName = networkOption?.label || selectedNetwork;
     const networkPath = networkName === "Ethereum" ? "Mainnet" : networkName;
+    const chainId = networkOption?.chainId || selectedNetwork;
 
     // Create just the filename - the path will come from the config
-    const filename = networkPath + `/set-swap-fee-${selectedPool.address}-${uniqueId}.json`;
+    const filename = `set-swap-fee-${chainId}-${selectedPool.address}-${uniqueId}.json`;
 
     return {
       prefillBranchName: `feature/swap-fee-${shortPoolId}-${uniqueId}`,

--- a/components/ChangeSwapFeeV3Module.tsx
+++ b/components/ChangeSwapFeeV3Module.tsx
@@ -313,9 +313,10 @@ export default function ChangeSwapFeeV3Module({ addressBook }: { addressBook: Ad
     const networkOption = NETWORK_OPTIONS.find(n => n.apiID === selectedNetwork);
     const networkName = networkOption?.label || selectedNetwork;
     const networkPath = networkName === "Ethereum" ? "Mainnet" : networkName;
+    const chainId = networkOption?.chainId || selectedNetwork;
 
-    // Create the filename with network path included
-    const filename = networkPath + `/set-swap-fee-${selectedPool.address}-${uniqueId}.json`;
+    // Create the filename with chain ID included
+    const filename = `set-swap-fee-${chainId}-${selectedPool.address}-${uniqueId}.json`;
 
     return {
       prefillBranchName: `feature/swap-fee-${shortPoolId}-${uniqueId}`,

--- a/components/EmergencyPayloadBuilder.tsx
+++ b/components/EmergencyPayloadBuilder.tsx
@@ -561,6 +561,7 @@ export default function EmergencyPayloadBuilder({ addressBook }: EmergencyPayloa
     const networkOption = NETWORK_OPTIONS.find(n => n.apiID === selectedNetwork);
     const networkName = networkOption?.label || selectedNetwork;
     const networkPath = networkName === "Ethereum" ? "Mainnet" : networkName;
+    const chainId = networkOption?.chainId || selectedNetwork;
 
     // Generate description
     const descriptions = [];
@@ -587,8 +588,7 @@ export default function EmergencyPayloadBuilder({ addressBook }: EmergencyPayloa
         : selectedPools.length > 0
           ? "pools"
           : "vault";
-    const filename =
-      networkPath + `/emergency-actions-${protocolVersion}-${actionType}-${uniqueId}.json`;
+    const filename = `emergency-actions-${chainId}-${protocolVersion}-${actionType}-${uniqueId}.json`;
 
     return {
       prefillBranchName: `emergency/${protocolVersion}-${actionType}-${uniqueId}`,

--- a/components/MevCaptureHookConfigurationModule.tsx
+++ b/components/MevCaptureHookConfigurationModule.tsx
@@ -225,9 +225,10 @@ export default function MevCaptureHookConfigurationModule({
     const networkOption = NETWORK_OPTIONS.find(n => n.apiID === selectedNetwork);
     const networkName = networkOption?.label || selectedNetwork;
     const networkPath = networkName === "Ethereum" ? "Mainnet" : networkName;
+    const chainId = networkOption?.chainId || selectedNetwork;
 
-    // Create the filename with network included
-    const filename = networkPath + `/mev-capture-params-${shortPoolId}-${uniqueId}.json`;
+    // Create the filename with chain ID included
+    const filename = `mev-capture-params-${chainId}-${shortPoolId}-${uniqueId}.json`;
 
     return {
       prefillBranchName: `feature/mev-capture-params-${shortPoolId}-${uniqueId}`,

--- a/components/ReClammModule.tsx
+++ b/components/ReClammModule.tsx
@@ -646,6 +646,7 @@ export default function ReClammModule({ addressBook }: { addressBook: AddressBoo
     const networkOption = NETWORK_OPTIONS.find(n => n.apiID === selectedNetwork);
     const networkName = networkOption?.label || selectedNetwork;
     const networkPath = networkName === "Ethereum" ? "Mainnet" : networkName;
+    const chainId = networkOption?.chainId || selectedNetwork;
 
     // Determine what parameters are being changed
     const hasCenterednessMargin = debouncedCenterednessMargin && isCenterednessMarginValid;
@@ -658,7 +659,7 @@ export default function ReClammModule({ addressBook }: { addressBook: AddressBoo
     let description: string;
 
     // Use same filename, branch name, and PR name for all cases
-    filename = networkPath + `/set-reclamm-parameters-${selectedPool.address}-${uniqueId}.json`;
+    filename = `set-reclamm-parameters-${chainId}-${selectedPool.address}-${uniqueId}.json`;
     branchName = `feature/reclamm-parameters-${shortPoolId}-${uniqueId}`;
     prName = `Set ReClaMM Parameters for ${poolName} on ${networkName}`;
 

--- a/components/RewardsInjectorConfigurator.tsx
+++ b/components/RewardsInjectorConfigurator.tsx
@@ -221,7 +221,8 @@ function RewardsInjectorConfigurator({
         : "";
 
     // Create the filename without any path prefix - the path will come from config
-    const filename = `injector-config-${shortInjectorId}-${uniqueId}.json`;
+    const chainId = getChainId(networkName);
+    const filename = `injector-config-${chainId}-${shortInjectorId}-${uniqueId}.json`;
 
     return {
       prefillBranchName: `feature/injector-config-${shortInjectorId}-${uniqueId}`,

--- a/components/RewardsInjectorConfiguratorV2.tsx
+++ b/components/RewardsInjectorConfiguratorV2.tsx
@@ -406,7 +406,8 @@ function RewardsInjectorConfiguratorV2({
     const operationCount = editedGauges.size + newlyAddedGauges.length + removedGauges.length;
     const summaryInfo = `updating ${operationCount} configuration${operationCount !== 1 ? "s" : ""}`;
 
-    const filename = `injector-update-${shortInjectorId}-${uniqueId}.json`;
+    const chainId = getChainId(networkName);
+    const filename = `injector-update-${chainId}-${shortInjectorId}-${uniqueId}.json`;
 
     return {
       prefillBranchName: `feature/injector-update-${shortInjectorId}-${uniqueId}`,

--- a/components/StableSurgeHookConfigurationModule.tsx
+++ b/components/StableSurgeHookConfigurationModule.tsx
@@ -170,9 +170,10 @@ export default function StableSurgeHookConfigurationModule({
     const networkOption = NETWORK_OPTIONS.find(n => n.apiID === selectedNetwork);
     const networkName = networkOption?.label || selectedNetwork;
     const networkPath = networkName === "Ethereum" ? "Mainnet" : networkName;
+    const chainId = networkOption?.chainId || selectedNetwork;
 
-    // Create the filename with network included
-    const filename = networkPath + `/stable-surge-params-${selectedPool.address}-${uniqueId}.json`;
+    // Create the filename with chain ID included
+    const filename = `stable-surge-params-${chainId}-${selectedPool.address}-${uniqueId}.json`;
 
     // Add the network to the OpenPRButton
     // This ensures the network is passed to the PR modal

--- a/constants/constants.ts
+++ b/constants/constants.ts
@@ -267,7 +267,7 @@ export const PAYLOAD_OPTIONS = [
     repos: ["balancer/multisig-ops"],
     branchNamePlaceholder: "feature/emergency-payload",
     prNamePlaceholder: "Create emergency payload for pool XYZ",
-    prTypePath: "OmniAutoOps/",
+    prTypePath: "MaxiOps/Emergency-Multisigs/",
   },
   {
     href: "/payload-builder/composer",


### PR DESCRIPTION
Flatten filepaths so that no network subfolders pop up anymore (e.g. in https://github.com/balancer/multisig-ops/pull/2804)