### PR TITLE
Payload builders: add query params

### DIFF
--- a/components/ChangeAmpFactorModule.tsx
+++ b/components/ChangeAmpFactorModule.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useQuery } from "@apollo/client/react";
+import { useSearchParams } from "next/navigation";
 import {
   Alert,
   AlertDescription,
@@ -49,6 +50,7 @@ import { TrendingUp } from "react-feather";
 import { NetworkSelector } from "@/components/NetworkSelector";
 import { generateUniqueId } from "@/lib/utils/generateUniqueID";
 import { getMultisigForNetwork } from "@/lib/utils/getMultisigForNetwork";
+import { updateQueryParams } from "@/lib/utils/updateQueryParams";
 import PoolSelector from "./PoolSelector";
 import { ParameterChangePreviewCard } from "./ParameterChangePreviewCard";
 import { useDebounce } from "use-debounce";
@@ -100,6 +102,10 @@ export default function ChangeAmpFactorModule({
 
   const toast = useToast();
   const { isOpen, onOpen, onClose } = useDisclosure();
+
+  const searchParams = useSearchParams();
+  const initialNetworkSetRef = useRef(false);
+  const initialPoolSetRef = useRef(false);
 
   // Get protocol-specific configuration
   const config = PROTOCOL_CONFIG[protocolVersion];
@@ -170,6 +176,35 @@ export default function ChangeAmpFactorModule({
 
   const resolveMultisig = (network: string) => getMultisigForNetwork(addressBook, network, config.multisigType);
 
+  // Pre-select network from `?network=` query param on first load
+  useEffect(() => {
+    if (initialNetworkSetRef.current) return;
+    const networkParam = searchParams.get("network");
+    if (!networkParam) return;
+
+    const networkOption = filteredNetworkOptions.find(
+      n => n.apiID.toLowerCase() === networkParam.toLowerCase(),
+    );
+    if (networkOption) {
+      setSelectedNetwork(networkOption.apiID);
+      setSelectedMultisig(resolveMultisig(networkOption.apiID));
+      initialNetworkSetRef.current = true;
+    }
+  }, [searchParams, filteredNetworkOptions, resolveMultisig]);
+
+  // Pre-select pool from `?pool=` query param once pool data is loaded
+  useEffect(() => {
+    if (initialPoolSetRef.current) return;
+    const poolParam = searchParams.get("pool");
+    if (!poolParam || filteredPools.length === 0 || !selectedNetwork) return;
+
+    const pool = filteredPools.find(p => p.address.toLowerCase() === poolParam.toLowerCase());
+    if (pool) {
+      setSelectedPool(pool as unknown as Pool);
+      initialPoolSetRef.current = true;
+    }
+  }, [searchParams, filteredPools, selectedNetwork]);
+
   const handleNetworkChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newNetwork = e.target.value;
     setSelectedNetwork(newNetwork);
@@ -178,6 +213,7 @@ export default function ChangeAmpFactorModule({
     setGeneratedPayload(null);
     setNewAmpFactor("");
     setEndDateTime("");
+    updateQueryParams({ network: newNetwork.toLowerCase(), pool: null });
   };
 
   const handlePoolSelect = (pool: Pool) => {
@@ -185,6 +221,7 @@ export default function ChangeAmpFactorModule({
     setGeneratedPayload(null);
     setNewAmpFactor("");
     setEndDateTime("");
+    updateQueryParams({ pool: pool.address.toLowerCase() });
   };
 
   const clearPoolSelection = () => {
@@ -192,6 +229,7 @@ export default function ChangeAmpFactorModule({
     setGeneratedPayload(null);
     setNewAmpFactor("");
     setEndDateTime("");
+    updateQueryParams({ pool: null });
   };
 
   const handleOpenPRModal = () => {

--- a/components/ChangeSwapFeeModule.tsx
+++ b/components/ChangeSwapFeeModule.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useQuery } from "@apollo/client/react";
+import { useSearchParams } from "next/navigation";
 import {
   Alert,
   AlertDescription,
@@ -55,6 +56,7 @@ import { DollarSign } from "react-feather";
 import { NetworkSelector } from "@/components/NetworkSelector";
 import { generateUniqueId } from "@/lib/utils/generateUniqueID";
 import { getMultisigForNetwork } from "@/lib/utils/getMultisigForNetwork";
+import { updateQueryParams } from "@/lib/utils/updateQueryParams";
 import { getCategoryData } from "@/lib/data/balancer/addressBook";
 import ComposerButton from "@/app/payload-builder/composer/ComposerButton";
 import ComposerIndicator from "@/app/payload-builder/composer/ComposerIndicator";
@@ -80,6 +82,10 @@ export default function ChangeSwapFeeModule({ addressBook }: ChangeSwapFeeProps)
   const toast = useToast();
   const { isOpen, onOpen, onClose } = useDisclosure();
   const filteredNetworkOptions = getNetworksForFeature("swapFeeChange");
+
+  const searchParams = useSearchParams();
+  const initialNetworkSetRef = useRef(false);
+  const initialPoolSetRef = useRef(false);
 
   const getPrefillValues = () => {
     // Make sure we have a selected pool and new swap fee
@@ -159,6 +165,7 @@ export default function ChangeSwapFeeModule({ addressBook }: ChangeSwapFeeProps)
 
   const handlePoolSelection = (pool: Pool) => {
     setSelectedPool(pool);
+    updateQueryParams({ pool: pool.address.toLowerCase() });
   };
 
   const clearPoolSelection = () => {
@@ -166,6 +173,7 @@ export default function ChangeSwapFeeModule({ addressBook }: ChangeSwapFeeProps)
     setGeneratedPayload(null);
     setNewSwapFee("");
     setUseGauntletFeeSetter(false);
+    updateQueryParams({ pool: null });
   };
 
   const handleNetworkChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -177,6 +185,7 @@ export default function ChangeSwapFeeModule({ addressBook }: ChangeSwapFeeProps)
     setSelectedPool(null);
     setGeneratedPayload(null);
     setNewSwapFee("");
+    updateQueryParams({ network: newNetwork.toLowerCase(), pool: null });
   };
 
   const handleOpenPRModal = () => {
@@ -198,6 +207,37 @@ export default function ChangeSwapFeeModule({ addressBook }: ChangeSwapFeeProps)
   const isGauntletAvailable = !!(gauntletFeeSetterAddress && feeManagerSafeAddress);
 
   const v2Pools = data?.poolGetPools?.filter(pool => pool.protocolVersion !== 3);
+
+  // Pre-select network from `?network=` query param on first load
+  useEffect(() => {
+    if (initialNetworkSetRef.current) return;
+    const networkParam = searchParams.get("network");
+    if (!networkParam) return;
+
+    const networkOption = filteredNetworkOptions.find(
+      n => n.apiID.toLowerCase() === networkParam.toLowerCase(),
+    );
+    if (networkOption) {
+      setSelectedNetwork(networkOption.apiID);
+      setSelectedMultisig(resolveMultisig(networkOption.apiID));
+      setGauntletFeeSetterAddress(resolveGauntletFeeSetter(networkOption.apiID));
+      setFeeManagerSafeAddress(resolveFeeManagerSafe(networkOption.apiID));
+      initialNetworkSetRef.current = true;
+    }
+  }, [searchParams, filteredNetworkOptions]);
+
+  // Pre-select pool from `?pool=` query param once pool data is loaded
+  useEffect(() => {
+    if (initialPoolSetRef.current) return;
+    const poolParam = searchParams.get("pool");
+    if (!poolParam || !v2Pools || !selectedNetwork) return;
+
+    const pool = v2Pools.find(p => p.address.toLowerCase() === poolParam.toLowerCase());
+    if (pool) {
+      setSelectedPool(pool as unknown as Pool);
+      initialPoolSetRef.current = true;
+    }
+  }, [searchParams, v2Pools, selectedNetwork]);
 
   // Color mode values for dark mode support
   const textColorSecondary = useColorModeValue("gray.600", "gray.400");

--- a/components/ChangeSwapFeeV3Module.tsx
+++ b/components/ChangeSwapFeeV3Module.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useQuery } from "@apollo/client/react";
+import { useSearchParams } from "next/navigation";
 import {
   Alert,
   AlertDescription,
@@ -61,6 +62,7 @@ import {
 } from "@/lib/hooks/validation/useValidateSwapFee";
 import { useDebounce } from "use-debounce";
 import { getMultisigForNetwork } from "@/lib/utils/getMultisigForNetwork";
+import { updateQueryParams } from "@/lib/utils/updateQueryParams";
 import ComposerButton from "@/app/payload-builder/composer/ComposerButton";
 import ComposerIndicator from "@/app/payload-builder/composer/ComposerIndicator";
 import { fetchAddressType } from "@/lib/services/fetchAddressType";
@@ -77,6 +79,10 @@ export default function ChangeSwapFeeV3Module({ addressBook }: { addressBook: Ad
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const [debouncedSwapFee] = useDebounce(newSwapFee, 300);
+
+  const searchParams = useSearchParams();
+  const initialNetworkSetRef = useRef(false);
+  const initialPoolSetRef = useRef(false);
 
   //Chain state switch
   const { switchChain } = useSwitchChain();
@@ -114,6 +120,37 @@ export default function ChangeSwapFeeV3Module({ addressBook }: { addressBook: Ad
     );
   })();
 
+  // Pre-select network from `?network=` query param on first load
+  useEffect(() => {
+    if (initialNetworkSetRef.current) return;
+    const networkParam = searchParams.get("network");
+    if (!networkParam) return;
+
+    const networkOption = networkOptionsWithV3.find(
+      n => n.apiID.toLowerCase() === networkParam.toLowerCase(),
+    );
+    if (networkOption) {
+      setSelectedNetwork(networkOption.apiID);
+      setSelectedMultisig(resolveMultisig(networkOption.apiID));
+      initialNetworkSetRef.current = true;
+    }
+  }, [searchParams, networkOptionsWithV3, resolveMultisig]);
+
+  // Pre-select pool from `?pool=` query param once pool data is loaded
+  useEffect(() => {
+    if (initialPoolSetRef.current) return;
+    const poolParam = searchParams.get("pool");
+    if (!poolParam || !data?.poolGetPools || !selectedNetwork) return;
+
+    const pool = data.poolGetPools.find(
+      p => p.address.toLowerCase() === poolParam.toLowerCase(),
+    );
+    if (pool) {
+      setSelectedPool(pool as unknown as Pool);
+      initialPoolSetRef.current = true;
+    }
+  }, [searchParams, data?.poolGetPools, selectedNetwork]);
+
   const handleNetworkChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newNetwork = e.target.value;
     setSelectedNetwork(newNetwork);
@@ -122,6 +159,7 @@ export default function ChangeSwapFeeV3Module({ addressBook }: { addressBook: Ad
     setGeneratedPayload(null);
     setNewSwapFee("");
     setIsCurrentWalletManager(false);
+    updateQueryParams({ network: newNetwork.toLowerCase(), pool: null });
 
     // Find the corresponding chain ID for the selected network
     const networkOption = networkOptionsWithV3.find(n => n.apiID === newNetwork);
@@ -142,6 +180,7 @@ export default function ChangeSwapFeeV3Module({ addressBook }: { addressBook: Ad
   // Check manager status when pool is selected
   const handlePoolSelection = async (pool: Pool) => {
     setSelectedPool(pool); // Set pool immediately for UI update
+    updateQueryParams({ pool: pool.address.toLowerCase() });
   };
 
   const clearPoolSelection = () => {
@@ -149,6 +188,7 @@ export default function ChangeSwapFeeV3Module({ addressBook }: { addressBook: Ad
     setGeneratedPayload(null);
     setNewSwapFee("");
     setIsCurrentWalletManager(false);
+    updateQueryParams({ pool: null });
   };
 
   const handleOpenPRModal = () => {

--- a/components/MevCaptureHookConfigurationModule.tsx
+++ b/components/MevCaptureHookConfigurationModule.tsx
@@ -57,6 +57,7 @@ import { useSearchParams } from "next/navigation";
 import { useValidateMevCapture } from "@/lib/hooks/validation/useValidateMevCapture";
 import { useDebounce } from "use-debounce";
 import { getMultisigForNetwork } from "@/lib/utils/getMultisigForNetwork";
+import { updateQueryParams } from "@/lib/utils/updateQueryParams";
 import { generateUniqueId } from "@/lib/utils/generateUniqueID";
 import ComposerButton from "@/app/payload-builder/composer/ComposerButton";
 import ComposerIndicator from "@/app/payload-builder/composer/ComposerIndicator";
@@ -171,6 +172,7 @@ export default function MevCaptureHookConfigurationModule({
     setNewMevTaxThreshold("");
     setNewMevTaxMultiplier("");
     setIsCurrentWalletManager(false);
+    updateQueryParams({ network: newNetwork.toLowerCase(), pool: null });
 
     // Find the corresponding chain ID for the selected network
     const networkOption = networkOptions.find(n => n.apiID === newNetwork);
@@ -240,6 +242,7 @@ export default function MevCaptureHookConfigurationModule({
 
   const handlePoolSelect = (pool: Pool) => {
     setSelectedPool(pool);
+    updateQueryParams({ pool: pool.address.toLowerCase() });
   };
 
   const clearPoolSelection = () => {
@@ -247,6 +250,7 @@ export default function MevCaptureHookConfigurationModule({
     setGeneratedPayload(null);
     setNewMevTaxThreshold("");
     setNewMevTaxMultiplier("");
+    updateQueryParams({ pool: null });
   };
 
   const handleOpenPRModal = () => {

--- a/components/ReClammModule.tsx
+++ b/components/ReClammModule.tsx
@@ -57,6 +57,7 @@ import { useDebounce } from "use-debounce";
 import ComposerButton from "@/app/payload-builder/composer/ComposerButton";
 import ComposerIndicator from "@/app/payload-builder/composer/ComposerIndicator";
 import { getMultisigForNetwork } from "@/lib/utils/getMultisigForNetwork";
+import { updateQueryParams } from "@/lib/utils/updateQueryParams";
 import { isZeroAddress } from "@ethereumjs/util";
 import { useValidateReclamm } from "@/lib/hooks/validation/useValidateReclamm";
 import { useSearchParams } from "next/navigation";
@@ -250,6 +251,7 @@ export default function ReClammModule({ addressBook }: { addressBook: AddressBoo
     setPriceRatioUpdateEndTime("");
     setStopPriceRatioUpdate(false);
     setIsCurrentWalletManager(false);
+    updateQueryParams({ network: newNetwork.toLowerCase(), pool: null });
 
     // Find the corresponding chain ID for the selected network
     const networkOption = networkOptionsWithV3.find(n => n.apiID === newNetwork);
@@ -269,6 +271,7 @@ export default function ReClammModule({ addressBook }: { addressBook: AddressBoo
 
   const handlePoolSelection = (pool: Pool) => {
     setSelectedPool(pool);
+    updateQueryParams({ pool: pool.address.toLowerCase() });
   };
 
   // Effect to handle URL parameters and auto-select pool
@@ -312,6 +315,7 @@ export default function ReClammModule({ addressBook }: { addressBook: AddressBoo
     setPriceRatioUpdateEndTime("");
     setStopPriceRatioUpdate(false);
     setIsCurrentWalletManager(false);
+    updateQueryParams({ pool: null });
   };
 
   const handleOpenPRModal = () => {

--- a/components/StableSurgeHookConfigurationModule.tsx
+++ b/components/StableSurgeHookConfigurationModule.tsx
@@ -62,6 +62,7 @@ import { useSearchParams } from "next/navigation";
 import { useDebounce } from "use-debounce";
 import { useValidateStableSurge } from "@/lib/hooks/validation/useValidateStableSurge";
 import { getMultisigForNetwork } from "@/lib/utils/getMultisigForNetwork";
+import { updateQueryParams } from "@/lib/utils/updateQueryParams";
 import { generateUniqueId } from "@/lib/utils/generateUniqueID";
 import ComposerButton from "@/app/payload-builder/composer/ComposerButton";
 import ComposerIndicator from "@/app/payload-builder/composer/ComposerIndicator";
@@ -233,6 +234,7 @@ export default function StableSurgeHookConfigurationModule({
     setNewMaxSurgeFeePercentage("");
     setNewSurgeThresholdPercentage("");
     setIsCurrentWalletManager(false);
+    updateQueryParams({ network: newNetwork.toLowerCase(), pool: null });
 
     // Find the corresponding chain ID for the selected network
     const networkOption = networkOptionsWithV3.find(n => n.apiID === newNetwork);
@@ -253,6 +255,7 @@ export default function StableSurgeHookConfigurationModule({
   // Check manager status when pool is selected
   const handlePoolSelect = (pool: Pool) => {
     setSelectedPool(pool);
+    updateQueryParams({ pool: pool.address.toLowerCase() });
   };
 
   const clearPoolSelection = () => {
@@ -260,6 +263,7 @@ export default function StableSurgeHookConfigurationModule({
     setGeneratedPayload(null);
     setNewMaxSurgeFeePercentage("");
     setNewSurgeThresholdPercentage("");
+    updateQueryParams({ pool: null });
   };
 
   const handleOpenPRModal = () => {

--- a/lib/utils/updateQueryParams.ts
+++ b/lib/utils/updateQueryParams.ts
@@ -1,0 +1,18 @@
+// Updates the current URL's query string in place via history.replaceState,
+// so deep links stay shareable as the user changes selections without
+// triggering a navigation or re-running route effects.
+//
+// Pass `null` or "" to remove a param.
+export function updateQueryParams(params: Record<string, string | null | undefined>) {
+  if (typeof window === "undefined") return;
+
+  const url = new URL(window.location.href);
+  for (const [key, value] of Object.entries(params)) {
+    if (value === null || value === undefined || value === "") {
+      url.searchParams.delete(key);
+    } else {
+      url.searchParams.set(key, value);
+    }
+  }
+  window.history.replaceState({ ...window.history.state }, "", url.toString());
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -10,7 +14,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {
@@ -18,7 +22,9 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     },
     "target": "ES2017"
   },


### PR DESCRIPTION
To be in line with other payload builder modules, I am adding query params to all relevant modules, which are:
- v3 fee setter
- amp factor updater
- ReCLAMM configurator (needs separate update for AutoRange funcitonality)
- MEV Capture hook

This feature will enable us to directly link new analytics sites with parameter change pages on the Ops UI which is great UX!