### PR TITLE
Fix: Github OAuth flow and PR Modal error handling

### DIFF
--- a/app/api/github/check-status/route.ts
+++ b/app/api/github/check-status/route.ts
@@ -50,10 +50,39 @@ export async function GET(req: NextRequest) {
     const githubTokenEncrypted = user.accounts[0].access_token;
     const githubToken = decrypt(githubTokenEncrypted);
 
+    // Undecryptable token -> fail clearly instead of an opaque downstream 401/500.
+    if (!githubToken) {
+      return NextResponse.json(
+        {
+          message:
+            "Could not read your stored GitHub credentials. Please sign out and reconnect GitHub.",
+          code: "TOKEN_DECRYPT_FAILED",
+        },
+        { status: 401 },
+      );
+    }
+
     const octokit = new Octokit({ auth: githubToken });
 
-    // Get authenticated user
-    const { data: authUser } = await octokit.users.getAuthenticated();
+    // A 401 here means the stored OAuth token was revoked/expired -> ask the user to
+    // reconnect rather than returning a generic 500.
+    let authUser;
+    try {
+      const { data } = await octokit.users.getAuthenticated();
+      authUser = data;
+    } catch (error) {
+      const status = (error as { status?: number })?.status;
+      if (status === 401) {
+        return NextResponse.json(
+          {
+            message: "Your GitHub session has expired. Please sign out and reconnect GitHub.",
+            code: "GITHUB_TOKEN_INVALID",
+          },
+          { status: 401 },
+        );
+      }
+      throw error;
+    }
 
     // Check if fork exists
     let fork;
@@ -63,8 +92,8 @@ export async function GET(req: NextRequest) {
         repo: repoName,
       });
       fork = existingFork;
-    } catch (error) {
-      // If fork doesn't exist, return early
+    } catch {
+      // Fork doesn't exist -> nothing to compare.
       return NextResponse.json(
         {
           isOutdated: false,
@@ -80,35 +109,60 @@ export async function GET(req: NextRequest) {
       owner,
       repo: repoName,
     });
-    const defaultBranch = parentRepo.default_branch;
+    const upstreamBranch = parentRepo.default_branch;
+    // Use the fork's own default branch: older forks may still be on "master".
+    const forkBranch = fork.default_branch || upstreamBranch;
 
-    // Compare the fork with the original repo using compareCommitsWithBasehead
-    // Format: BASE...HEAD where BASE is the fork and HEAD is the original repo
-    const compareString = `${authUser.login}:${defaultBranch}...${owner}:${defaultBranch}`;
+    // Cross-fork compare (BASE=fork ... HEAD=upstream). This is the fragile, per-user
+    // step and can fail (404/422/5xx). It must not block PR creation, so on failure we
+    // degrade to "status unknown, assume up to date" rather than surfacing a 500.
+    const compareString = `${authUser.login}:${forkBranch}...${owner}:${upstreamBranch}`;
 
-    const { data: comparison } = await octokit.repos.compareCommitsWithBasehead({
-      owner,
-      repo: repoName,
-      basehead: compareString,
-    });
+    try {
+      const { data: comparison } = await octokit.repos.compareCommitsWithBasehead({
+        owner,
+        repo: repoName,
+        basehead: compareString,
+      });
 
-    // Calculate how many commits behind the fork is
-    const behindBy = comparison.ahead_by; // We use ahead_by because we're comparing fork->original
-    const isOutdated = behindBy > 0;
+      // ahead_by = commits upstream (HEAD) is ahead of the fork (BASE) = how far behind the fork is.
+      const behindBy = comparison.ahead_by;
+      const isOutdated = behindBy > 0;
 
-    return NextResponse.json(
-      {
-        forkRepo: fork.full_name,
-        isOutdated,
-        behindBy,
-        hasFork: true,
-        defaultBranch,
-        message: isOutdated
-          ? `Fork is ${behindBy} commits behind the original repository`
-          : "Fork is up to date",
-      },
-      { status: 200 },
-    );
+      return NextResponse.json(
+        {
+          forkRepo: fork.full_name,
+          isOutdated,
+          behindBy,
+          hasFork: true,
+          defaultBranch: upstreamBranch,
+          message: isOutdated
+            ? `Fork is ${behindBy} commits behind the original repository`
+            : "Fork is up to date",
+        },
+        { status: 200 },
+      );
+    } catch (compareError) {
+      const status = (compareError as { status?: number })?.status;
+      console.error(
+        `Fork comparison failed for ${compareString} (status ${status ?? "unknown"}):`,
+        compareError,
+      );
+
+      // Non-blocking: keep the modal usable; statusUnknown lets the UI note it.
+      return NextResponse.json(
+        {
+          forkRepo: fork.full_name,
+          isOutdated: false,
+          hasFork: true,
+          statusUnknown: true,
+          defaultBranch: upstreamBranch,
+          message:
+            "Could not determine whether your fork is up to date. If your PR fails, sync your fork on GitHub and try again.",
+        },
+        { status: 200 },
+      );
+    }
   } catch (error) {
     console.error("Error details:", error);
     const err = error as Error;

--- a/app/api/github/pr/route.ts
+++ b/app/api/github/pr/route.ts
@@ -66,7 +66,6 @@ export async function POST(req: NextRequest) {
 
     const githubTokenEncrypted = user.accounts[0].access_token;
     const githubToken = decrypt(githubTokenEncrypted);
-    console.log(githubToken);
 
     const octokit = new Octokit({ auth: githubToken });
 

--- a/auth.ts
+++ b/auth.ts
@@ -4,6 +4,31 @@ import { PrismaAdapter } from "@auth/prisma-adapter";
 import prisma from "@/prisma/prisma";
 import { encrypt } from "@/lib/config/encrypt";
 
+// Upsert the (encrypted) OAuth token onto the account row. Called on both the
+// first link and every subsequent sign-in so a returning user's token stays fresh.
+// Failures here must never block sign-in, so they are caught and logged.
+async function persistGithubToken(account: any) {
+  if (!account?.provider || !account?.providerAccountId || !account.access_token) return;
+
+  try {
+    await prisma.account.update({
+      where: {
+        provider_providerAccountId: {
+          provider: account.provider,
+          providerAccountId: account.providerAccountId,
+        },
+      },
+      data: {
+        access_token: encrypt(account.access_token),
+        refresh_token: account.refresh_token ? encrypt(account.refresh_token) : undefined,
+        expires_at: account.expires_at ?? undefined,
+      },
+    });
+  } catch (error) {
+    console.error("Failed to persist refreshed GitHub token:", error);
+  }
+}
+
 export const { auth, handlers, signIn, signOut } = NextAuth({
   adapter: PrismaAdapter(prisma),
   providers: [
@@ -18,24 +43,21 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
     }),
   ],
   events: {
-    async linkAccount({ user, account, profile }: { user: any; account: any; profile?: any }) {
-      const updatedAccount = {
-        ...account,
-        access_token: account.access_token ? encrypt(account.access_token) : undefined,
-        refresh_token: account.refresh_token ? encrypt(account.refresh_token) : undefined,
-      };
-      await prisma.account.update({
-        where: {
-          provider_providerAccountId: {
-            provider: account.provider,
-            providerAccountId: account.providerAccountId,
-          },
-        },
-        data: {
-          access_token: updatedAccount.access_token,
-          refresh_token: updatedAccount.refresh_token,
-        },
-      });
+    // Persist the freshly-issued OAuth token (encrypted) into the account row.
+    //
+    // IMPORTANT: `linkAccount` fires ONLY on the first time an account is linked.
+    // For every subsequent sign-in of a returning user, Auth.js creates a session
+    // WITHOUT updating the account, so the stored token would otherwise be frozen at
+    // its first-login value forever. Once GitHub revokes/expires that token, the user
+    // is permanently stuck (fork checks and PR creation 401), and neither re-login,
+    // cache clears, nor fork syncs recover it. We therefore ALSO refresh the token on
+    // every `signIn` (which does fire for returning users) so a re-login heals a stale
+    // or revoked token.
+    async linkAccount({ account }: any) {
+      await persistGithubToken(account);
+    },
+    async signIn({ account }: any) {
+      await persistGithubToken(account);
     },
   },
 });

--- a/components/modal/PRModal.tsx
+++ b/components/modal/PRModal.tsx
@@ -41,6 +41,7 @@ import {
   isSameWeek,
 } from "date-fns";
 import { generateUniqueId } from "@/lib/utils/generateUniqueID";
+import { signIn } from "next-auth/react";
 
 interface PRCreationModalProps {
   isOpen: boolean;
@@ -90,6 +91,7 @@ export const PRCreationModal: React.FC<PRCreationModalProps> = ({
   const repoOptions = payloadOption ? payloadOption.repos : [];
 
   const [forkStatus, setForkStatus] = useState<ForkStatus | null>(null);
+  const [authError, setAuthError] = useState<string | null>(null);
   const [prRepo, setPrRepo] = useState(repoOptions[0] || "");
   const [prBranch, setPrBranch] = useState("");
   const [prName, setPrName] = useState("");
@@ -176,40 +178,54 @@ export const PRCreationModal: React.FC<PRCreationModalProps> = ({
     return filePath || "";
   };
 
-  useEffect(() => {
+  // Fetch fork status. Distinguishes an expired/revoked GitHub token (401) so the UI
+  // can offer a reconnect action instead of a dead-end error toast.
+  const fetchForkStatus = async ({ showSuccessToast = false } = {}) => {
+    if (!prRepo) return;
+
     setIsLoading(true);
-    const checkForkStatus = async () => {
-      if (!isOpen || !prRepo) return;
+    setAuthError(null);
+    try {
+      const response = await fetch(`/api/github/check-status?repo=${prRepo}`);
+      const data = await response.json().catch(() => ({}));
 
-      try {
-        const response = await fetch(`/api/github/check-status?repo=${prRepo}`, {
-          method: "GET",
-          headers: {
-            "Content-Type": "application/json",
-          },
-        });
-
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
+      if (!response.ok) {
+        if (response.status === 401) {
+          setAuthError(
+            data?.message || "Your GitHub session has expired. Please reconnect to continue.",
+          );
+          return;
         }
+        throw new Error(data?.error || data?.message || `HTTP error! status: ${response.status}`);
+      }
 
-        const status = await response.json();
-        setForkStatus(status);
-      } catch (error) {
-        console.error("Error checking fork status:", error);
+      setForkStatus(data);
+
+      if (showSuccessToast) {
         toast({
-          title: "Error checking fork status",
-          description: error instanceof Error ? error.message : "An unknown error occurred",
-          status: "error",
-          duration: 5000,
+          title: "Fork status refreshed",
+          status: "success",
+          duration: 2000,
           isClosable: true,
         });
-      } finally {
-        setIsLoading(false);
       }
-    };
+    } catch (error) {
+      console.error("Error checking fork status:", error);
+      toast({
+        title: "Error checking fork status",
+        description: error instanceof Error ? error.message : "An unknown error occurred",
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
-    checkForkStatus();
+  useEffect(() => {
+    if (!isOpen || !prRepo) return;
+    fetchForkStatus();
   }, [isOpen, prRepo]);
 
   const handleWeekChange = (direction: "prev" | "next") => {
@@ -296,43 +312,12 @@ export const PRCreationModal: React.FC<PRCreationModalProps> = ({
     window.open(url, "_blank");
   };
 
-  const handleRefreshForkStatus = async () => {
-    if (!prRepo) return;
+  const handleRefreshForkStatus = () => fetchForkStatus({ showSuccessToast: true });
 
-    setIsLoading(true);
-    try {
-      const response = await fetch(`/api/github/check-status?repo=${prRepo}`, {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-        },
-      });
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-
-      const status = await response.json();
-      setForkStatus(status);
-
-      toast({
-        title: "Fork status refreshed",
-        status: "success",
-        duration: 2000,
-        isClosable: true,
-      });
-    } catch (error) {
-      console.error("Error checking fork status:", error);
-      toast({
-        title: "Error checking fork status",
-        description: error instanceof Error ? error.message : "An unknown error occurred",
-        status: "error",
-        duration: 5000,
-        isClosable: true,
-      });
-    } finally {
-      setIsLoading(false);
-    }
+  // Re-run the GitHub OAuth flow. On success the token is re-persisted server-side
+  // (see auth.ts signIn event), which heals a stale/revoked token.
+  const handleReconnectGitHub = () => {
+    signIn("github");
   };
 
   const handleFilePathChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -346,6 +331,31 @@ export const PRCreationModal: React.FC<PRCreationModalProps> = ({
       <ModalContent>
         <ModalHeader>Create Pull Request</ModalHeader>
         <ModalCloseButton />
+        {authError && (
+          <Alert status="error" mb={4}>
+            <AlertIcon />
+            <Box flex="1">
+              <AlertTitle>GitHub connection expired</AlertTitle>
+              <AlertDescription display="block">
+                {authError} Reconnecting refreshes your access token and resolves this.
+              </AlertDescription>
+              <Flex mt={2} gap={2}>
+                <Button size="sm" colorScheme="red" onClick={handleReconnectGitHub}>
+                  Reconnect GitHub
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  leftIcon={<RepeatIcon />}
+                  onClick={handleRefreshForkStatus}
+                  isLoading={isLoading}
+                >
+                  Retry
+                </Button>
+              </Flex>
+            </Box>
+          </Alert>
+        )}
         {forkStatus?.isOutdated && (
           <Alert status="warning" mb={4}>
             <AlertIcon />

--- a/lib/config/encrypt.ts
+++ b/lib/config/encrypt.ts
@@ -15,7 +15,6 @@ function encrypt(text: string): string {
 
 function decrypt(text: string): string | null {
   try {
-    console.log("Attempting to decrypt:", text);
     const textParts = text.split(":");
     if (textParts.length !== 2) {
       console.error("Invalid encrypted text format");
@@ -27,11 +26,10 @@ function decrypt(text: string): string | null {
     const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
     let decrypted = decipher.update(encryptedText);
     decrypted = Buffer.concat([decrypted, decipher.final()]);
-    const result = decrypted.toString();
-    console.log("Decryption successful. Token length:", result.length);
-    return result;
+    return decrypted.toString();
   } catch (error) {
-    console.error("Decryption error:", error);
+    // Do not log the ciphertext or plaintext — only the failure itself.
+    console.error("Decryption error:", error instanceof Error ? error.message : error);
     return null;
   }
 }


### PR DESCRIPTION
Fixes the persistent "error checking fork status" 500 that a handful of users (reported by Danko) hit on PR creation. 

Root cause: their stored GitHub OAuth token was stale/revoked and never got refreshed — we only write it to the DB in the   
  linkAccount event, which fires on first login only. So for returning users the token was frozen forever, and no cache clear, re-login or fork sync could recover it.                                                                              
                                                                                                                                                                                                                                                    
  Changes:                                                                                                                                                                                                                                          
  - auth.ts: refresh the encrypted token on every sign-in (new signIn event next to linkAccount, sharing a persistGithubToken() helper). Reconnecting now heals a stale/revoked token — this is the actual fix.                                     
  - check-status route: real error handling instead of a blanket 500 — undecryptable token → 401 (TOKEN_DECRYPT_FAILED), revoked/expired → 401 (GITHUB_TOKEN_INVALID), use the fork's own default branch (handles old master forks), and the fragile
  cross-fork compare now degrades to a non-blocking statusUnknown instead of blocking PR creation.                                                                                                                                                  
  - PRModal.tsx: dedupe the fork-status fetch and add a "Reconnect GitHub" button on 401, so stuck users get a self-serve fix instead of a dead-end toast.                                                                                          
  - Security clean-up: removed token leaks into server logs (plaintext token in the PR route, ciphertext + token length in encrypt.ts).   